### PR TITLE
Improve iOS LAN host routing and logging for simplified deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Xcode user-specific data
+*.xcodeproj/xcuserdata/
+*.xcworkspace/xcuserdata/
+
+# CocoaPods user-specific data
+Pods/*.xcodeproj/xcuserdata/
+
+# Local build artifacts
+build/

--- a/EulixSpace.xcodeproj/project.pbxproj
+++ b/EulixSpace.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -612,10 +612,7 @@
 		9336793F2924BE4A002A40C6 /* ESAppStoreCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9336793E2924BE4A002A40C6 /* ESAppStoreCell.m */; };
 		93367943292602A1002A40C6 /* ESAppStoreModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 93367942292602A1002A40C6 /* ESAppStoreModel.m */; };
 		933B7FC8285ABFD800C304E5 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 933B7FC7285ABFD800C304E5 /* Security.framework */; };
-		933B7FC9285AC01900C304E5 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93059B32282CD6F700EA61BD /* SystemConfiguration.framework */; };
 		933B7FCB285AC02200C304E5 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 933B7FCA285AC02200C304E5 /* CoreGraphics.framework */; };
-		933B7FCC285AC02E00C304E5 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 93059B36282CD71A00EA61BD /* libsqlite3.tbd */; };
-		933B7FCE285AC03600C304E5 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93059B34282CD70000EA61BD /* CoreTelephony.framework */; };
 		933B7FCF285AC05E00C304E5 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 93059B38282CD71F00EA61BD /* libz.tbd */; };
 		933C488B26AA55A500E20770 /* ESFileTotalVC.m in Sources */ = {isa = PBXBuildFile; fileRef = 933C488A26AA55A500E20770 /* ESFileTotalVC.m */; };
 		933C488E26AA55F500E20770 /* ESFilePhotoVC.m in Sources */ = {isa = PBXBuildFile; fileRef = 933C488D26AA55F500E20770 /* ESFilePhotoVC.m */; };
@@ -3064,10 +3061,6 @@
 				93059B3B282CD89D00EA61BD /* UserNotifications.framework in Frameworks */,
 				93059B35282CD70000EA61BD /* CoreTelephony.framework in Frameworks */,
 				3433C29626A56FF400E3B093 /* CloudKit.framework in Frameworks */,
-				933B7FCC285AC02E00C304E5 /* libsqlite3.tbd in Frameworks */,
-				933B7FC9285AC01900C304E5 /* SystemConfiguration.framework in Frameworks */,
-				933B7FCE285AC03600C304E5 /* CoreTelephony.framework in Frameworks */,
-				933B7FCF285AC05E00C304E5 /* libz.tbd in Frameworks */,
 				93B21C4526D7960000B5D8D4 /* Social.framework in Frameworks */,
 				933B7FCB285AC02200C304E5 /* CoreGraphics.framework in Frameworks */,
 				9E0FC74CBAD38CEABC77A67C /* libPods-EulixSpace.a in Frameworks */,
@@ -6654,8 +6647,9 @@
 		341EC48D2665E66E008F5DA8 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				CLASSPREFIX = ES;
-				LastUpgradeCheck = 1330;
+				LastUpgradeCheck = 1600;
 				ORGANIZATIONNAME = eulix.xyz;
 				TargetAttributes = {
 					341EC4942665E66E008F5DA8 = {
@@ -7099,7 +7093,6 @@
 				2C84C9BD2A6524D0003383BC /* ESShareAgainReq.m in Sources */,
 				2CEB23F7288F8D8400418923 /* NSError+ESTool.m in Sources */,
 				2C84C9872A6524D0003383BC /* ESRevokeClientResult.m in Sources */,
-				2CEB23F7288F8D8400418923 /* NSError+ESTool.m in Sources */,
 				9354588B2872CF270034017E /* ESShareListCell.m in Sources */,
 				2C84CA1D2A6524D0003383BC /* ESRestoreTransId.m in Sources */,
 				936A7D972A4D129E0060863C /* ESRedirectManage.m in Sources */,
@@ -7776,7 +7769,6 @@
 				F0317D1C28E19CE3001357AB /* ESBaseActionSheetVC.m in Sources */,
 				2C84C9752A6524D0003383BC /* ESResponseBaseUserEntity.m in Sources */,
 				2CD7D3F328C5FC9B00E0879C /* ESSecurityPasswordModifyCell.m in Sources */,
-				2CD7D3F328C5FC9B00E0879C /* ESSecurityPasswordModifyCell.m in Sources */,
 				34D54D2826D7711D004173B3 /* UIImage+ESTool.m in Sources */,
 				345C9CE226F5C31A0007B5F8 /* UIImageView+ESThumb.m in Sources */,
 				F0895FC02869FE3100A1D105 /* ESContactAuthorizationStatusCommand.m in Sources */,
@@ -7886,6 +7878,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEV=1";
@@ -7990,6 +7983,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -8050,6 +8044,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = "APPSTORE=1";
@@ -8079,7 +8074,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = CYL6T9HFC7;
 				ENABLE_BITCODE = NO;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = EulixSpace/Application/EulixSpace_Prefix.pch;
 				INFOPLIST_FILE = EulixSpace/Application/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -8203,6 +8197,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = "PLATFORM=1";

--- a/EulixSpace/Business/Box/Bind/ESBoxBindLocalNetworkModule.m
+++ b/EulixSpace/Business/Box/Bind/ESBoxBindLocalNetworkModule.m
@@ -177,6 +177,7 @@ static const CGFloat kESBoxBindSearchTimeout = 40;
     [self reset];
     self.btid = uniqueId;
     self.serviceUUID = [self.btid uuidFrombtid];
+    ESDLog(@"[Bind][Local] start search btid:%@ mode:%ld", self.btid, (long)self.parentModule.mode);
     ///eulixspace-%@
     NSString *localName = [NSString stringWithFormat:TEXT_BOX_BLUETOOTH_NAME_FORMAT, self.btid];
 
@@ -196,6 +197,7 @@ static const CGFloat kESBoxBindSearchTimeout = 40;
 - (void)setupServiceBrowserWithScanNetServiceInfo {
     _serviceBrowser = [ESNetServiceBrowser new];
     self.mdnsItem = self.scanNetServiceInfo;
+    ESDLog(@"[Bind][Local] use fixed address %@:%d", self.mdnsItem.ipv4, self.mdnsItem.port);
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@:%d", self.mdnsItem.ipv4, self.mdnsItem.port]];
     ESApiClient *client = [[ESApiClient alloc] initWithBaseURL:url];
     client.timeoutInterval = self.boxStatus.infoResult.initialEstimateTimeSec;;
@@ -213,8 +215,12 @@ static const CGFloat kESBoxBindSearchTimeout = 40;
     req.signedBtid = [pair sign:self.btid];
   
     ESPairApi *api = [[ESPairApi alloc] initWithApiClient:self.apiClient];
+    ESDLog(@"[Bind][Local] pubKeyExchange request btid:%@", self.btid);
     [api pubKeyExchangeWithPubKeyExchangeReq:req
                            completionHandler:^(ESRspPubKeyExchangeRsp *output, NSError *error) {
+                            ESDLog(@"[Bind][Local] pubKeyExchange response code:%@ err:%@",
+                                   output.code,
+                                   error.localizedDescription);
                             if ((error != nil || output.results.boxPubKey == nil) &&
                                 self.parentModule.mode == ESBoxBindModeWiredConnectionWithIp ) {
                                 // 设备无法连接
@@ -233,8 +239,12 @@ static const CGFloat kESBoxBindSearchTimeout = 40;
     req.encBtid = encBtid;
    
     ESPairApi *api = [[ESPairApi alloc] initWithApiClient:self.apiClient];
+    ESDLog(@"[Bind][Local] aesKeyExchange request btid:%@", self.btid);
     [api keyExchangeWithKeyExchangeReq:req
                      completionHandler:^(ESRspKeyExchangeRsp *output, NSError *error) {
+                         ESDLog(@"[Bind][Local] aesKeyExchange response code:%@ err:%@",
+                                output.code,
+                                error.localizedDescription);
                          [self onAESKeyExchange:output];
                      }];
 }
@@ -246,8 +256,10 @@ static const CGFloat kESBoxBindSearchTimeout = 40;
     }
   
     [self stopTimer];
+    ESDLog(@"[Bind][Local] loadBoxStatus from %@", self.apiClient.baseURL.absoluteString);
     
     [ESNetworkRequestManager sendRequest:self.apiClient.baseURL.absoluteString path:@"/agent/v1/api/pair/init" method:@"GET" queryParams:nil header:nil body:nil modelName:nil successBlock:^(NSInteger requestId, NSString * response) {
+        ESDLog(@"[Bind][Local] pair/init success requestId:%ld", (long)requestId);
         
         NSString * encodeJson = [self decrypt:response];
         ESBindInitResultModel * tmpModel = [ESBindInitResultModel yy_modelWithJSON:encodeJson];
@@ -261,6 +273,10 @@ static const CGFloat kESBoxBindSearchTimeout = 40;
         [self onInit:respModel];
         
     } failBlock:^(NSInteger requestId, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        ESDLog(@"[Bind][Local] pair/init failed requestId:%ld code:%@ msg:%@",
+               (long)requestId,
+               [error codeString],
+               error.localizedDescription);
         ESBindInitResp * respModel = [[ESBindInitResp alloc] init];
         respModel.code = error.userInfo[@"code"];
         respModel.message = error.userInfo[@"message"];

--- a/EulixSpace/Business/Box/Initialization/ESApiClient+ESHost.m
+++ b/EulixSpace/Business/Box/Initialization/ESApiClient+ESHost.m
@@ -30,29 +30,63 @@
 
 @implementation ESApiClient (ESHost)
 
+static BOOL ESHostIsLoopbackURL(NSURL *url) {
+    NSString *host = url.host.lowercaseString;
+    return [host isEqualToString:@"localhost"] || [host isEqualToString:@"127.0.0.1"];
+}
+
+static BOOL ESHostIsUsableHTTPURL(NSString *value) {
+    if (value.length == 0) {
+        return NO;
+    }
+    NSURL *url = [NSURL URLWithString:value];
+    if (url == nil || url.scheme.length == 0 || url.host.length == 0) {
+        return NO;
+    }
+    NSString *scheme = url.scheme.lowercaseString;
+    return [scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"];
+}
+
 + (void)load {
     [self es_swizzleSEL:@selector(es_baseURL) withSEL:@selector(baseURL)];
 }
 
 - (NSURL *)es_baseURL {
+    ESBoxItem *activeBox = ESBoxManager.activeBox;
+    NSString *activeLocalHost = @"";
+    if (activeBox != nil &&
+        activeBox.enableInternetAccess == NO &&
+        ESHostIsUsableHTTPURL(activeBox.localHost)) {
+        activeLocalHost = activeBox.localHost;
+    }
+
     if (self.boxItem != nil &&
         self.boxItem.enableInternetAccess == NO &&
-        self.boxItem.localHost.length > 0) {
+        ESHostIsUsableHTTPURL(self.boxItem.localHost)) {
+        // If this client is accidentally bound to a stale box, force active LAN host.
+        if (activeLocalHost.length > 0 &&
+            activeBox != nil &&
+            self.boxItem.boxUUID.length > 0 &&
+            ![self.boxItem.boxUUID isEqualToString:activeBox.boxUUID]) {
+            ESDLog(@"es_baseURL activeBox(stale-box override) url  %@", activeLocalHost);
+            return [NSURL URLWithString:activeLocalHost];
+        }
         NSString *userDomain = self.boxItem.localHost;
         ESDLog(@"es_baseURL boxItem url  %@", userDomain);
         return [NSURL URLWithString:userDomain];
     }
-    
-    if (ESBoxManager.activeBox != nil &&
-        ESBoxManager.activeBox.enableInternetAccess == NO &&
-        (self.es_baseURL.absoluteString.length <= 0 || ([self.es_baseURL.absoluteString hasSuffix:ESSafeString(ESBoxManager.activeBox.prettyDomain)]))&&
-        ESBoxManager.activeBox.localHost.length > 0) {
-        NSString *userDomain = ESBoxManager.activeBox.localHost;
+
+    NSURL *rawBaseURL = self.es_baseURL;
+    NSString *rawBaseURLString = ESSafeString(rawBaseURL.absoluteString);
+    if (activeLocalHost.length > 0 &&
+        (rawBaseURLString.length <= 0 ||
+         ESHostIsLoopbackURL(rawBaseURL) ||
+         [rawBaseURLString hasSuffix:ESSafeString(activeBox.prettyDomain)])) {
+        NSString *userDomain = activeLocalHost;
         ESDLog(@"es_baseURL activeBox url  %@", userDomain);
         return [NSURL URLWithString:userDomain];
     }
-    ESDLog(@"es_baseURL url  %@", self.es_baseURL);
-    return self.es_baseURL;
+    return rawBaseURL;
 }
 
 static void *gApiClientBindBox = &gApiClientBindBox;

--- a/EulixSpace/Business/Box/Initialization/ESSpaceChannelInfoVC.m
+++ b/EulixSpace/Business/Box/Initialization/ESSpaceChannelInfoVC.m
@@ -132,6 +132,10 @@
     
     id<ESTitleDetailSwitchListItemProtocol> cellModel = self.listModule.listData[1];
     NSString * platformUrl = cellModel.platformAddress;
+    ESDLog(@"[Bind][SpaceCreate] nextStep internetOn:%d platformUrl:%@ hasViewModel:%d",
+           self.isInternetOn,
+           platformUrl,
+           self.viewModel != nil);
     if (cellModel.isOn && ![self isValidPlatformUrl:platformUrl]) {
         return;
     }
@@ -156,6 +160,9 @@
         };
         
         [self.view showLoading:YES];
+        ESDLog(@"[Bind][SpaceCreate] sendSpaceCreate clientUuid:%@ spaceName:%@",
+               ESBoxManager.clientUUID,
+               self.viewModel.spaceName);
         [self.viewModel sendSpaceCreate:req];
         return;
     }
@@ -163,6 +170,7 @@
     if (self.boxItem != nil) {
         weakfy(self)
         [self.view showLoading:YES];
+        ESDLog(@"[Bind][Channel] update internet service config internetOn:%d", self.isInternetOn);
         [ESNetworkRequestManager sendCallRequestWithServiceName:@"eulixspace-agent-service"
                                                         apiName:@"internet_service_config"
                                                     queryParams:@{}
@@ -172,6 +180,7 @@
                                                                 }
                                                       modelName:nil
                                                    successBlock:^(NSInteger requestId, id  _Nullable response) {
+            ESDLog(@"[Bind][Channel] internet_service_config success requestId:%ld", (long)requestId);
             strongfy(self)
             ESBoxManager.activeBox.enableInternetAccess = self.isInternetOn;
             ESInternetServiceConfigModel *config = [ESInternetServiceConfigModel yy_modelWithDictionary:response];
@@ -191,6 +200,10 @@
             [ESToast toastSuccess:NSLocalizedString(@"security_authensetsuccess", @"设置成功")];
             [self updateActionBtStatus];
         } failBlock:^(NSInteger requestId, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+            ESDLog(@"[Bind][Channel] internet_service_config failed requestId:%ld code:%@ msg:%@",
+                   (long)requestId,
+                   [error codeString],
+                   error.localizedDescription);
             [self.view showLoading:NO];
             [self updateActionBtStatus];
 
@@ -209,6 +222,7 @@
 
 - (void)onBindCommand:(ESBCCommandType)command resp:(NSDictionary *)response {
     if (command == ESBCCommandTypeBindSpaceCreateReq) {
+        ESDLog(@"[Bind][SpaceCreate] response code:%@ requestId:%@", response[@"code"], response[@"requestId"]);
         [self.view showLoading:NO];
         if ([response[@"code"] isEqualToString:@"AG-200"]) {
             [ESToast toastSuccess:NSLocalizedString(@"security_authensetsuccess", @"设置成功")];

--- a/EulixSpace/Business/Me/DeviceInfo/Modules/ESDeviceInfoServiceModule.m
+++ b/EulixSpace/Business/Me/DeviceInfo/Modules/ESDeviceInfoServiceModule.m
@@ -28,6 +28,7 @@
 @implementation ESDeviceInfoServiceModule
 
 + (void)getDeviceInfoWithCompletion:(ESDeviceInfoServiceCompletionBlock)completionBlock {
+    ESDLog(@"[DeviceInfo] request device_version");
     [ESNetworkRequestManager sendCallRequest:@{
                                                 @"serviceName" : @"eulixspace-agent-service",
                                                 @"apiName" : @"device_version"
@@ -37,11 +38,16 @@
                                         body:@{}
                                    modelName:@"ESDeviceInfoResultModel"
                                 successBlock:^(NSInteger requestId, id  _Nullable response) {
+                                    ESDLog(@"[DeviceInfo] success requestId:%ld", (long)requestId);
                                     if (completionBlock) {
                                         completionBlock(response, nil);
                                     }
                                    }
                                    failBlock:^(NSInteger requestId, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+                                    ESDLog(@"[DeviceInfo] failed requestId:%ld code:%@ msg:%@",
+                                           (long)requestId,
+                                           error.userInfo[@"code"],
+                                           error.localizedDescription);
                                     if (completionBlock) {
                                         completionBlock(nil, error);
                                     }

--- a/EulixSpace/ESPlatform/Network/ESNetworkRequestManager.m
+++ b/EulixSpace/ESPlatform/Network/ESNetworkRequestManager.m
@@ -33,6 +33,30 @@ NSInteger const ESRequestID_InVailed = -1;
 static NSInteger const TVSPBRequestDefaultRetryCount = 3;
 static NSString * const TVSPBRequestDefaultRetryCountKey = @"pb_retry_count";
 
+static NSString *ESNetworkRequestApiDesc(NSDictionary *apiParams) {
+    if (![apiParams isKindOfClass:[NSDictionary class]]) {
+        return @"unknown";
+    }
+    NSString *serviceName = apiParams[ESNetworkServiceNameKey];
+    NSString *apiName = apiParams[ESNetworkApiNameKey];
+    if (serviceName.length == 0 && apiName.length == 0) {
+        return @"unknown";
+    }
+    return [NSString stringWithFormat:@"%@/%@",
+            serviceName.length > 0 ? serviceName : @"-",
+            apiName.length > 0 ? apiName : @"-"];
+}
+
+static NSString *ESNetworkRequestKeysDesc(NSDictionary *dict) {
+    if (![dict isKindOfClass:[NSDictionary class]] || dict.count == 0) {
+        return @"[]";
+    }
+    NSArray *keys = [dict.allKeys sortedArrayUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
+        return [[obj1 description] compare:[obj2 description]];
+    }];
+    return [NSString stringWithFormat:@"%@", keys];
+}
+
 @interface ESNetworkRequestManager() <NSURLSessionDelegate>
 
 @property (nonatomic, strong)NSMutableArray<ESNetworkRequestServiceTask *> *requestList;
@@ -129,6 +153,12 @@ static NSString * const TVSPBRequestDefaultRetryCountKey = @"pb_retry_count";
                  queryParams:queryParams
                       header:headerParams
                         body:bodyParams];
+    ESDLog(@"[Network] enqueue raw request id:%ld method:%@ path:%@ queryKeys:%@ bodyKeys:%@",
+           (long)requestTask.requestId,
+           method,
+           path,
+           ESNetworkRequestKeysDesc(queryParams),
+           ESNetworkRequestKeysDesc(bodyParams));
     return requestTask.requestId;
 }
 
@@ -153,6 +183,13 @@ static NSString * const TVSPBRequestDefaultRetryCountKey = @"pb_retry_count";
                  queryParams:queryParams
                       header:headerParams
                         body:bodyParams];
+    ESDLog(@"[Network] enqueue raw request id:%ld method:%@ base:%@ path:%@ queryKeys:%@ bodyKeys:%@",
+           (long)requestTask.requestId,
+           method,
+           baseUrl,
+           path,
+           ESNetworkRequestKeysDesc(queryParams),
+           ESNetworkRequestKeysDesc(bodyParams));
     return requestTask.requestId;
 }
 
@@ -192,6 +229,11 @@ static NSString * const TVSPBRequestDefaultRetryCountKey = @"pb_retry_count";
                      queryParams:queryParams
                           header:headerParams
                             body:bodyParams];
+    ESDLog(@"[Network] enqueue call request id:%ld api:%@ queryKeys:%@ bodyKeys:%@",
+           (long)requestTask.requestId,
+           ESNetworkRequestApiDesc(apiParams),
+           ESNetworkRequestKeysDesc(queryParams),
+           ESNetworkRequestKeysDesc(bodyParams));
     return requestTask.requestId;
 }
 
@@ -213,6 +255,12 @@ static NSString * const TVSPBRequestDefaultRetryCountKey = @"pb_retry_count";
                           header:headerParams
                             body:bodyParams
                         filePath:filePath];
+    ESDLog(@"[Network] enqueue upload(file) id:%ld api:%@ file:%@ queryKeys:%@ bodyKeys:%@",
+           (long)requestTask.requestId,
+           ESNetworkRequestApiDesc(apiParams),
+           filePath.lastPathComponent,
+           ESNetworkRequestKeysDesc(queryParams),
+           ESNetworkRequestKeysDesc(bodyParams));
     return requestTask.requestId;
 }
 
@@ -234,6 +282,12 @@ static NSString * const TVSPBRequestDefaultRetryCountKey = @"pb_retry_count";
                           header:headerParams
                             body:bodyParams
                         data:data];
+    ESDLog(@"[Network] enqueue upload(data) id:%ld api:%@ dataLength:%lu queryKeys:%@ bodyKeys:%@",
+           (long)requestTask.requestId,
+           ESNetworkRequestApiDesc(apiParams),
+           (unsigned long)data.length,
+           ESNetworkRequestKeysDesc(queryParams),
+           ESNetworkRequestKeysDesc(bodyParams));
     return requestTask.requestId;
 }
 
@@ -252,6 +306,11 @@ static NSString * const TVSPBRequestDefaultRetryCountKey = @"pb_retry_count";
                               header:headerParams
                                 body:bodyParams
                               method:method];
+    ESDLog(@"[Network] enqueue download id:%ld method:%@ queryKeys:%@ bodyKeys:%@",
+           (long)requestTask.requestId,
+           method,
+           ESNetworkRequestKeysDesc(queryParams),
+           ESNetworkRequestKeysDesc(bodyParams));
     
     return requestTask.requestId;
 }
@@ -276,6 +335,12 @@ static NSString * const TVSPBRequestDefaultRetryCountKey = @"pb_retry_count";
                                 body:bodyParams
                               targetPath:targetPath
     ];
+    ESDLog(@"[Network] enqueue call download id:%ld api:%@ target:%@ queryKeys:%@ bodyKeys:%@",
+           (long)requestTask.requestId,
+           ESNetworkRequestApiDesc(apiParams),
+           targetPath.lastPathComponent,
+           ESNetworkRequestKeysDesc(queryParams),
+           ESNetworkRequestKeysDesc(bodyParams));
     
     return requestTask.requestId;
 }
@@ -286,6 +351,7 @@ static NSString * const TVSPBRequestDefaultRetryCountKey = @"pb_retry_count";
         if (task) {
             [task cancel];
             [[ESNetworkRequestManager sharedInstance] removeRequest:task];
+            ESDLog(@"[Network] cancel request id:%ld", (long)requestId);
         }
     });
 }

--- a/EulixSpace/Manager/API/BoxGateway/ESGatewayManager.h
+++ b/EulixSpace/Manager/API/BoxGateway/ESGatewayManager.h
@@ -42,4 +42,13 @@ typedef void (^ESGatewayManageOnToken)(ESTokenItem *token, NSError *error);
 
 - (void)refreshToken:(ESBoxItem *)activeBox callback:(ESGatewayManageOnToken)callback;
 
+/// Exposed for unit tests: decide whether lanHost can override current box baseUrl.
++ (BOOL)shouldUseLanHost:(NSString *)lanHost
+            reachableBox:(ESBoxItem *)reachableBox
+               activeBox:(ESBoxItem *)activeBox;
+
+/// Exposed for unit tests: reject stale requests that do not belong to the current active box.
++ (BOOL)isActiveBoxRequest:(ESBoxItem *)requestBox
+                 activeBox:(ESBoxItem *)activeBox;
+
 @end

--- a/EulixSpace/Manager/API/BoxGateway/ESGatewayManager.m
+++ b/EulixSpace/Manager/API/BoxGateway/ESGatewayManager.m
@@ -64,6 +64,31 @@
     dispatch_semaphore_t _lock;
 }
 
++ (BOOL)shouldUseLanHost:(NSString *)lanHost
+            reachableBox:(ESBoxItem *)reachableBox
+               activeBox:(ESBoxItem *)activeBox {
+    if (lanHost.length == 0 || !reachableBox || !activeBox) {
+        return NO;
+    }
+    if (reachableBox.boxUUID.length > 0 && activeBox.boxUUID.length > 0) {
+        return [reachableBox.boxUUID isEqualToString:activeBox.boxUUID];
+    }
+    return [reachableBox isEqual:activeBox];
+}
+
++ (BOOL)isActiveBoxRequest:(ESBoxItem *)requestBox
+                 activeBox:(ESBoxItem *)activeBox {
+    // If there is no active box yet, do not block request startup.
+    if (!requestBox || !activeBox) {
+        return YES;
+    }
+    if (requestBox.boxUUID.length > 0 && activeBox.boxUUID.length > 0) {
+        return requestBox.boxType == activeBox.boxType &&
+               [requestBox.boxUUID isEqualToString:activeBox.boxUUID];
+    }
+    return [requestBox isEqual:activeBox];
+}
+
 + (instancetype)manager {
     static dispatch_once_t once = 0;
     static id instance = nil;
@@ -107,6 +132,17 @@
     activeBox = activeBox ?: ESBoxManager.activeBox;
     dispatch_async(self.queue, ^{
         Lock();
+        if (![ESGatewayManager isActiveBoxRequest:activeBox activeBox:ESBoxManager.activeBox]) {
+            ESDLog(@"[ESGatewayManager] skip stale box token request request:%@ active:%@",
+                   ESSafeString(activeBox.boxUUID),
+                   ESSafeString(ESBoxManager.activeBox.boxUUID));
+            NSError *staleError = [NSError errorWithDomain:NSURLErrorDomain
+                                                      code:NSURLErrorCancelled
+                                                  userInfo:@{NSLocalizedDescriptionKey : @"stale box token request cancelled"}];
+            [self callback:callback token:nil error:staleError];
+            Unlock();
+            return;
+        }
         ///授权的盒子
         if (activeBox.auth) {
             if (activeBox.authToken.valid) {
@@ -139,15 +175,16 @@
             ESDLog(@"[activeBox.localHost] lanHost:%@", baseUrl);
         }
         
-        NSString * lanHost = [[ESLocalNetworking shared] getLanHost];
-        if ([ESLocalNetworking shared].reachableBox && lanHost.length > 0) {
+        ESBoxItem *reachableBox = [ESLocalNetworking shared].reachableBox;
+        NSString *lanHost = [[ESLocalNetworking shared] getLanHost];
+        if ([ESGatewayManager shouldUseLanHost:lanHost reachableBox:reachableBox activeBox:activeBox]) {
             baseUrl = lanHost;
             ESDLog(@"[ESLocalNetworking] lanHost:%@", baseUrl);
-
-//            if (![ESBoxManager.activeBox.localHost isEqualToString:lanHost]) {
-//                ESBoxManager.activeBox.localHost = lanHost;
-//                [ESBoxManager.manager saveBox:ESBoxManager.activeBox];
-//            }
+        } else if (reachableBox && lanHost.length > 0) {
+            ESDLog(@"[ESLocalNetworking] skip lanHost override due to box mismatch, reachable:%@ active:%@ host:%@",
+                   ESSafeString(reachableBox.boxUUID),
+                   ESSafeString(activeBox.boxUUID),
+                   lanHost);
         }
         
         if (activeBox.boxType == ESBoxTypeMember) {
@@ -263,15 +300,27 @@
                   ESCallRequest *callRequest = [ESCallRequest new];
                   callRequest.accessToken = token.accessToken;
 
-                  ESDLog(@"plain call input :\n%@", request.json);
+                  ESDLog(@"[GatewayCall][input] service:%@ api:%@ requestId:%@ payloadLen:%lu",
+                         request.serviceName,
+                         request.apiName,
+                         request.requestId,
+                         (unsigned long)request.json.length);
                   callRequest.body = [request.json aes_cbc_encryptWithKey:token.secretKey iv:token.secretIV];
                   [api spaceV1ApiGatewayCallPostWithBody:callRequest
                                        completionHandler:^(ESRealCallResult *output, NSError *error) {
                                            NSString *plainBody = [output.body aes_cbc_decryptWithKey:token.secretKey iv:token.secretIV];
                                            if (error) {
-                                               ESDLog(@"plain call error:\n%@", error.localizedDescription);
+                                               ESDLog(@"[GatewayCall][error] service:%@ api:%@ requestId:%@ error:%@",
+                                                      request.serviceName,
+                                                      request.apiName,
+                                                      request.requestId,
+                                                      error.localizedDescription);
                                            } else {
-                                               ESDLog(@"plain call output:\n%@", plainBody);
+                                               ESDLog(@"[GatewayCall][output] service:%@ api:%@ requestId:%@ payloadLen:%lu",
+                                                      request.serviceName,
+                                                      request.apiName,
+                                                      request.requestId,
+                                                      (unsigned long)plainBody.length);
                                            }
                                            if (callback) {
                                                callback([plainBody toJson] ?: plainBody, error);

--- a/EulixSpace/Manager/Box/ESBoxManager.m
+++ b/EulixSpace/Manager/Box/ESBoxManager.m
@@ -102,6 +102,26 @@ static NSString *const kESBoxManagerBoxListKey = @"_kESBoxManagerBoxListKey";
 
 @implementation ESBoxManager
 
+- (void)syncActiveBoxWithBoxList {
+    if (self.boxList.count == 0) {
+        self.activeBox = nil;
+        return;
+    }
+    if (!self.activeBox) {
+        self.activeBox = self.boxList.firstObject;
+        return;
+    }
+    __block ESBoxItem *matched = nil;
+    [self.boxList enumerateObjectsUsingBlock:^(ESBoxItem * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        if ([obj isEqual:self.activeBox]) {
+            matched = obj;
+            *stop = YES;
+        }
+    }];
+    // onParing appends to tail; when cached box is stale, prefer most recently added box.
+    self.activeBox = matched ?: self.boxList.lastObject;
+}
+
 + (instancetype)manager {
     static dispatch_once_t once = 0;
     static id instance = nil;
@@ -135,11 +155,12 @@ static NSString *const kESBoxManagerBoxListKey = @"_kESBoxManagerBoxListKey";
             }
             [self saveBoxList];
         }
+        [self syncActiveBoxWithBoxList];
         ///授权的盒子, token 失效了, 直接删除
         if (self.activeBox.boxType == ESBoxTypeAuth && !self.activeBox.authToken.valid) {
             [self.boxList removeObject:self.activeBox];
             [self saveBoxList];
-            self.activeBox = self.boxList.firstObject;
+            self.activeBox = self.boxList.lastObject;
         }
         ///激活当前盒子
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -978,4 +999,3 @@ static NSString *const kESBoxManagerBoxListKey = @"_kESBoxManagerBoxListKey";
 }
 
 @end
-

--- a/EulixSpace/Manager/Networking/ESLanTransferManager.h
+++ b/EulixSpace/Manager/Networking/ESLanTransferManager.h
@@ -54,6 +54,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)hasCertData;
 - (void)reqCertIfNot;
 
+/// Exposed for unit tests: normalize cert payload from multi-style API responses.
++ (NSString * _Nullable)extractLanCertFromResponse:(id _Nullable)response;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/EulixSpace/Manager/Networking/ESLanTransferManager.m
+++ b/EulixSpace/Manager/Networking/ESLanTransferManager.m
@@ -106,6 +106,31 @@ typedef void (^ESLanTaskCompletionHandler)(NSURLResponse *response, id responseO
     self.session = session;
 }
 
++ (NSString * _Nullable)extractLanCertFromResponse:(id _Nullable)response {
+    if ([response isKindOfClass:[NSString class]]) {
+        return (NSString *)response;
+    }
+    if (![response isKindOfClass:[NSDictionary class]]) {
+        return nil;
+    }
+    NSDictionary *dict = (NSDictionary *)response;
+    NSString *cert = dict[@"cert"];
+    if (cert.length > 0) {
+        return cert;
+    }
+    id nested = dict[@"results"];
+    if ([nested isKindOfClass:[NSDictionary class]]) {
+        NSString *nestedCert = nested[@"cert"];
+        if (nestedCert.length > 0) {
+            return nestedCert;
+        }
+    } else if ([nested isKindOfClass:[NSString class]]) {
+        return (NSString *)nested;
+    }
+    return nil;
+}
+
+
 - (BOOL)hasCertData {
     return self.certData != nil && self.certData.length > 0;
 }
@@ -123,9 +148,9 @@ typedef void (^ESLanTaskCompletionHandler)(NSURLResponse *response, id responseO
     self.isReqingCert = YES;
     [ESNetworkRequestManager sendCallRequestWithServiceName:eulixspace_agent_service apiName:get_lan_cert queryParams:nil header:nil body:nil modelName:nil successBlock:^(NSInteger requestId, id  _Nullable response) {
         self.isReqingCert = NO;
-        NSString * certStr = response[@"cert"];
+        NSString * certStr = [ESLanTransferManager extractLanCertFromResponse:response];
         if (!certStr) {
-            ESDLog(@"[上传下载] 自签名证书请求-内容为nil");
+            ESDLog(@"[上传下载] 自签名证书请求-内容为nil, response:%@", response);
             return;
         }
         

--- a/EulixSpace/Manager/Transfer/ESTransferManager.m
+++ b/EulixSpace/Manager/Transfer/ESTransferManager.m
@@ -392,6 +392,7 @@ typedef void (^ESCompletionHandler)(void);
          visible:(BOOL)visible
         callback:(void (^)(NSURL *output, NSError *error))callback {
     NSString *fileId = file.uuid;
+    ESDLog(@"[Transfer][Download] enqueue uuid:%@ name:%@ visible:%d", fileId, file.name, visible);
     ESTransferTask *task = [self taskExist:fileId];
     task.downloadingSemaphore = self.downloadingSemaphore;
     ///本地已经存在该文件, 可能是之前下载过的, 就不继续下载了,
@@ -546,6 +547,7 @@ typedef void (^ESCompletionHandler)(void);
 -(void)downloadBySlice:(ESTransferTask *)task {
     [task updateDownloadTaskState:ESTransferStateRunning];
     [task addTaskObserver:self];
+    ESDLog(@"[Transfer][Download] start uuid:%@ name:%@", task.file.uuid, task.name);
     
     ESRealCallRequest *request = [ESRealCallRequest new];
     request.apiName = @"download_file";
@@ -566,6 +568,10 @@ typedef void (^ESCompletionHandler)(void);
 
 - (void)processDownloadResult:(ESTransferTask *)task result:(NSURL *)url error:(NSError *)error {
     if (error || url == nil || url.path.length == 0) {
+        ESDLog(@"[Transfer][Download] failed uuid:%@ name:%@ err:%@",
+               task.file.uuid,
+               task.name,
+               error.localizedDescription);
         [task updateDownloadTaskState:ESTransferStateFailed];
         [self updateDownloadQueue:task];
         [task callDownloadResult:url error:error];
@@ -586,9 +592,16 @@ typedef void (^ESCompletionHandler)(void);
         }
         [task updateDownloadTaskState:ESTransferStateCompleted];
         [self updateDownloadQueue:task];
+        ESDLog(@"[Transfer][Download] completed uuid:%@ name:%@ path:%@",
+               task.file.uuid,
+               task.name,
+               url.path);
         
         [task callDownloadResult:url error:error];
     } else {
+        ESDLog(@"[Transfer][Download] failed missing file after download uuid:%@ name:%@",
+               task.file.uuid,
+               task.name);
         [task updateDownloadTaskState:ESTransferStateFailed];
         [task callDownloadResult:url error:error];
     }
@@ -715,8 +728,10 @@ typedef void (^ESCompletionHandler)(void);
 #pragma mark - Upload
 - (void)upload:(ESUploadMetadata *)metadata
       callback:(void (^)(ESRspUploadRspBody *result, NSError *error))callback {
+    ESDLog(@"[Transfer][Upload] enqueue fileName:%@ folderId:%@", metadata.fileName, metadata.folderId);
     for (ESTransferTask *task in self.uploadingQueue) {
         if([task.metadata.fileName isEqualToString:metadata.fileName]){
+            ESDLog(@"[Transfer][Upload] skip duplicate fileName:%@", metadata.fileName);
             return;
         }
     }
@@ -907,6 +922,10 @@ typedef void (^ESCompletionHandler)(void);
 - (void)processUploadResult:(ESTransferTask *)task result:(ESRspUploadRspBody *)result error:(NSError *)error {
     BOOL isAutoSyncTask = [self isAutoSyncTask:task];
     if (!result || error != nil) {
+        ESDLog(@"[Transfer][Upload] failed file:%@ err:%@ code:%@",
+               task.name,
+               error.localizedDescription,
+               result.code);
         if (isAutoSyncTask) {
             [task updateUploadTaskState:ESTransferStateFailed];
             [self.autoSyncUploadingQueue removeObject:task];
@@ -923,6 +942,7 @@ typedef void (^ESCompletionHandler)(void);
     }
     
     [task updateUploadTaskState:ESTransferStateCompleted];
+    ESDLog(@"[Transfer][Upload] completed file:%@ uuid:%@", task.name, result.results.uuid);
     //移除待上传文件
     [task.filePath.fullCachePath clearCachePath];
     

--- a/EulixSpaceTests/EulixSpaceTests.m
+++ b/EulixSpaceTests/EulixSpaceTests.m
@@ -31,7 +31,9 @@
 #import "ESRSAPair+openssl.h"
 #import "ESTransferManager.h"
 #import "ESApiClient.h"
-#import <ESClient/ESDefaultApi.h>
+#import "ESLogger.h"
+#import "ESNetworkRequestManager.h"
+#import "ESLanTransferManager.h"
 #import <XCTest/XCTest.h>
 
 @interface EulixSpaceTests : XCTestCase
@@ -93,6 +95,103 @@
     XCTAssertTrue([@"0.5.0" compare:@"0.5.1" options:NSNumericSearch] == NSOrderedAscending);
     XCTAssertTrue([@"0.5.1" compare:@"0.5.1" options:NSNumericSearch] == NSOrderedSame);
     XCTAssertTrue([@"0.5.10" compare:@"0.5.9" options:NSNumericSearch] == NSOrderedDescending);
+}
+
+- (void)testLoggerWriteToFile {
+    ESLogger *logger = [ESLogger sharedLogger];
+    logger.enabled = YES;
+    NSString *tmpPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"eslogger-%@.log", NSUUID.UUID.UUIDString]];
+    logger.loggingFile = tmpPath;
+
+    [logger debugLog:@"UnitTest" message:@"logger_file_write_%@", @"ok"];
+
+    NSData *data = [NSData dataWithContentsOfFile:tmpPath];
+    XCTAssertNotNil(data);
+    NSString *content = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    XCTAssertTrue([content containsString:@"logger_file_write_ok"]);
+
+    [[NSFileManager defaultManager] removeItemAtPath:tmpPath error:nil];
+}
+
+- (void)testNetworkRequestInvalidIdStatus {
+    ESNetworkRequestServiceStatus status = [ESNetworkRequestManager requestTaskStatusWithId:-1];
+    XCTAssertEqual(status, ESNetworkRequestServiceStatus_Unknow);
+}
+
+- (void)testRoutersContainsCoreFileApis {
+    NSString *testDir = [NSString stringWithUTF8String:__FILE__].stringByDeletingLastPathComponent;
+    NSString *routerPath = [[testDir stringByAppendingPathComponent:@"../EulixSpace/Resource/eulix.bundle/routers.json"] stringByStandardizingPath];
+    NSData *routerData = [NSData dataWithContentsOfFile:routerPath];
+    XCTAssertNotNil(routerData);
+    NSString *content = [[NSString alloc] initWithData:routerData encoding:NSUTF8StringEncoding];
+    XCTAssertNotNil(content);
+
+    XCTAssertTrue([content containsString:@"\"eulixspace-file-service\""]);
+    XCTAssertTrue([content containsString:@"/space/v1/api/file/upload"]);
+    XCTAssertTrue([content containsString:@"/space/v1/api/file/download"]);
+    XCTAssertTrue([content containsString:@"/space/v1/api/multipart/create"]);
+    XCTAssertTrue([content containsString:@"/space/v1/api/file/list"]);
+}
+
+- (void)testGatewayLanHostOverrideOnlyForSameBox {
+    ESBoxItem *activeBox = [ESBoxItem fromInviteMemberWithBoxUUID:@"box-a"
+                                                           authKey:@"auth-a"
+                                                        userDomain:@"a.local"
+                                                              aoid:@"aoid-a"];
+    ESBoxItem *sameReachableBox = [ESBoxItem fromInviteMemberWithBoxUUID:@"box-a"
+                                                                  authKey:@"auth-a2"
+                                                               userDomain:@"a2.local"
+                                                                     aoid:@"aoid-a"];
+    ESBoxItem *otherReachableBox = [ESBoxItem fromInviteMemberWithBoxUUID:@"box-b"
+                                                                   authKey:@"auth-b"
+                                                                userDomain:@"b.local"
+                                                                      aoid:@"aoid-b"];
+
+    XCTAssertTrue([ESGatewayManager shouldUseLanHost:@"http://192.168.0.10:80"
+                                        reachableBox:sameReachableBox
+                                           activeBox:activeBox]);
+    XCTAssertFalse([ESGatewayManager shouldUseLanHost:@"http://192.168.0.11:80"
+                                         reachableBox:otherReachableBox
+                                            activeBox:activeBox]);
+    XCTAssertFalse([ESGatewayManager shouldUseLanHost:@""
+                                         reachableBox:sameReachableBox
+                                            activeBox:activeBox]);
+}
+
+- (void)testGatewayRejectsStaleBoxRequest {
+    ESBoxItem *activeBox = [ESBoxItem fromInviteMemberWithBoxUUID:@"box-a"
+                                                           authKey:@"auth-a"
+                                                        userDomain:@"a.local"
+                                                              aoid:@"aoid-a"];
+    ESBoxItem *sameBoxNewObj = [ESBoxItem fromInviteMemberWithBoxUUID:@"box-a"
+                                                               authKey:@"auth-a2"
+                                                            userDomain:@"a2.local"
+                                                                  aoid:@"aoid-a"];
+    ESBoxItem *staleBox = [ESBoxItem fromInviteMemberWithBoxUUID:@"box-b"
+                                                          authKey:@"auth-b"
+                                                       userDomain:@"b.local"
+                                                             aoid:@"aoid-b"];
+
+    XCTAssertTrue([ESGatewayManager isActiveBoxRequest:sameBoxNewObj activeBox:activeBox]);
+    XCTAssertFalse([ESGatewayManager isActiveBoxRequest:staleBox activeBox:activeBox]);
+    XCTAssertTrue([ESGatewayManager isActiveBoxRequest:nil activeBox:activeBox]);
+}
+
+- (void)testLanCertResponseExtraction {
+    NSString *certA = [ESLanTransferManager extractLanCertFromResponse:@{@"cert" : @"abc"}];
+    XCTAssertEqualObjects(certA, @"abc");
+
+    NSString *certB = [ESLanTransferManager extractLanCertFromResponse:@{@"results" : @"def"}];
+    XCTAssertEqualObjects(certB, @"def");
+
+    NSString *certC = [ESLanTransferManager extractLanCertFromResponse:@{@"results" : @{@"cert" : @"ghi"}}];
+    XCTAssertEqualObjects(certC, @"ghi");
+
+    NSString *certD = [ESLanTransferManager extractLanCertFromResponse:@"jkl"];
+    XCTAssertEqualObjects(certD, @"jkl");
+
+    NSString *certE = [ESLanTransferManager extractLanCertFromResponse:@{}];
+    XCTAssertNil(certE);
 }
 
 @end

--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,6 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
       config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '9.0'
-      config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'arm64'
     end
   end
 end

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -16,6 +16,7 @@
 			dependencies = (
 			);
 			name = "OpenSSL-Universal";
+			productName = "OpenSSL-Universal";
 		};
 /* End PBXAggregateTarget section */
 
@@ -1466,9 +1467,9 @@
 		00B9E1059EE18D3C2675897AB0E436E1 /* WCTInterface.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTInterface.h; path = objc/WCDB/interface/declare/WCTInterface.h; sourceTree = "<group>"; };
 		00CC2D5B44FDDC8822162CEAF67D9362 /* SDImageCoderHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDImageCoderHelper.m; path = SDWebImage/Core/SDImageCoderHelper.m; sourceTree = "<group>"; };
 		00DACED96594CA7F3428BF96B71B7E96 /* WCTSelectBase+WCTExpr.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTSelectBase+WCTExpr.h"; path = "objc/WCDB/interface/orm/coding/WCTSelectBase+WCTExpr.h"; sourceTree = "<group>"; };
-		01830642CC9F7E039041215E35F1B8E8 /* crypto_cc.c */ = {isa = PBXFileReference; includeInIndex = 1; name = crypto_cc.c; path = src/crypto_cc.c; sourceTree = "<group>"; };
+		01830642CC9F7E039041215E35F1B8E8 /* crypto_cc.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = crypto_cc.c; path = src/crypto_cc.c; sourceTree = "<group>"; };
 		01A6912F6F977768AB35C55677AE2AAB /* WCTDatabase+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTDatabase+Private.h"; path = "objc/WCDB/interface/database/WCTDatabase+Private.h"; sourceTree = "<group>"; };
-		01DBDC6855EBC511EF961579D1A130F6 /* WCTDatabase+FTS.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTDatabase+FTS.mm"; path = "objc/WCDB/interface/fts/WCTDatabase+FTS.mm"; sourceTree = "<group>"; };
+		01DBDC6855EBC511EF961579D1A130F6 /* WCTDatabase+FTS.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTDatabase+FTS.mm"; path = "objc/WCDB/interface/fts/WCTDatabase+FTS.mm"; sourceTree = "<group>"; };
 		02022B64DE696840FE6815F2A17012A3 /* SAMKeychain.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SAMKeychain.h; path = Sources/SAMKeychain.h; sourceTree = "<group>"; };
 		0269CFEA90E5614A28E468F02C1B3E13 /* expr.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = expr.cpp; path = objc/WCDB/abstract/expr.cpp; sourceTree = "<group>"; };
 		02BB12B185403AF560BF90BCB2EE816D /* SDCycleScrollView.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SDCycleScrollView.release.xcconfig; sourceTree = "<group>"; };
@@ -1477,13 +1478,13 @@
 		032BCC9B0B6E6B3580218479E6358058 /* WCTStatement+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTStatement+Private.h"; path = "objc/WCDB/interface/core/WCTStatement+Private.h"; sourceTree = "<group>"; };
 		034EBD6018BB266A2C6E206E0565F125 /* JSONModel.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = JSONModel.release.xcconfig; sourceTree = "<group>"; };
 		0395C8E617AA33A1AABCA16CFA8CBFCE /* statement_attach.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_attach.cpp; path = objc/WCDB/abstract/statement_attach.cpp; sourceTree = "<group>"; };
-		03C5D544DF7AE1B4B118C4A2128AC0A0 /* mz_crypt.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mz_crypt.c; path = SSZipArchive/minizip/mz_crypt.c; sourceTree = "<group>"; };
-		03DD3D7169FE4F3535EB15335A894714 /* notify.c */ = {isa = PBXFileReference; includeInIndex = 1; name = notify.c; path = src/notify.c; sourceTree = "<group>"; };
-		03EBC375BDAF9B3A8C8050FCDD486C29 /* FileMD5Hash */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = FileMD5Hash; path = libFileMD5Hash.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		03C5D544DF7AE1B4B118C4A2128AC0A0 /* mz_crypt.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mz_crypt.c; path = SSZipArchive/minizip/mz_crypt.c; sourceTree = "<group>"; };
+		03DD3D7169FE4F3535EB15335A894714 /* notify.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = notify.c; path = src/notify.c; sourceTree = "<group>"; };
+		03EBC375BDAF9B3A8C8050FCDD486C29 /* libFileMD5Hash.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libFileMD5Hash.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		04664722715BE9E27E4E14BDE255F441 /* AFAutoPurgingImageCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFAutoPurgingImageCache.h; path = "UIKit+AFNetworking/AFAutoPurgingImageCache.h"; sourceTree = "<group>"; };
 		046ABF72F2B991E73A4F31FE23AFDF53 /* statement_transaction.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_transaction.cpp; path = objc/WCDB/abstract/statement_transaction.cpp; sourceTree = "<group>"; };
 		04711CA7DF94E2F37D83E5591A0B13CC /* Masonry-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Masonry-dummy.m"; sourceTree = "<group>"; };
-		0479A215B12F20130006557DF7C8840C /* loadext.c */ = {isa = PBXFileReference; includeInIndex = 1; name = loadext.c; path = src/loadext.c; sourceTree = "<group>"; };
+		0479A215B12F20130006557DF7C8840C /* loadext.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = loadext.c; path = src/loadext.c; sourceTree = "<group>"; };
 		04ADC4C55B048891B26C00755268B492 /* LOTGradientFillRender.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTGradientFillRender.h; path = "lottie-ios/Classes/RenderSystem/RenderNodes/LOTGradientFillRender.h"; sourceTree = "<group>"; };
 		0528A52F8387CE65E6D50ED63A9A2482 /* fts3_tokenizer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = fts3_tokenizer.h; path = ext/fts3/fts3_tokenizer.h; sourceTree = "<group>"; };
 		052C98DDB7C4119E5BC1481F28AD9A0C /* YYModel.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = YYModel.release.xcconfig; sourceTree = "<group>"; };
@@ -1492,10 +1493,10 @@
 		0617B5F788494F8E706611E2B7EE7745 /* DDTTYLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDTTYLogger.m; path = Sources/CocoaLumberjack/DDTTYLogger.m; sourceTree = "<group>"; };
 		063BD065C7B92C39DE59042852107842 /* error.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = error.hpp; path = objc/WCDB/util/error.hpp; sourceTree = "<group>"; };
 		064AEB25F082E43A6E7A7CF4DF6EB00D /* LOTRadialGradientLayer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTRadialGradientLayer.h; path = "lottie-ios/Classes/Extensions/LOTRadialGradientLayer.h"; sourceTree = "<group>"; };
-		0690258F465B5F24F1400B58A4F223DB /* func.c */ = {isa = PBXFileReference; includeInIndex = 1; name = func.c; path = src/func.c; sourceTree = "<group>"; };
+		0690258F465B5F24F1400B58A4F223DB /* func.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = func.c; path = src/func.c; sourceTree = "<group>"; };
 		0693F500F5E437FF65F247252A32570B /* JSONModel+networking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "JSONModel+networking.h"; path = "JSONModel/JSONModelNetworking/JSONModel+networking.h"; sourceTree = "<group>"; };
 		06AC4B408A8D9F7C0A2DAF13A75344BC /* SDFileAttributeHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDFileAttributeHelper.m; path = SDWebImage/Private/SDFileAttributeHelper.m; sourceTree = "<group>"; };
-		06C3324D5120E3D9D9DCFF9D3335EAD5 /* WCTDatabase+Database.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTDatabase+Database.mm"; path = "objc/WCDB/interface/database/WCTDatabase+Database.mm"; sourceTree = "<group>"; };
+		06C3324D5120E3D9D9DCFF9D3335EAD5 /* WCTDatabase+Database.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTDatabase+Database.mm"; path = "objc/WCDB/interface/database/WCTDatabase+Database.mm"; sourceTree = "<group>"; };
 		06E6937DB97977039F4B92192D4C2707 /* LOTShapeStroke.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTShapeStroke.m; path = "lottie-ios/Classes/Models/LOTShapeStroke.m"; sourceTree = "<group>"; };
 		06EA196A161F92A335021DEB82F2F1CC /* LOTPolystarAnimator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTPolystarAnimator.h; path = "lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPolystarAnimator.h"; sourceTree = "<group>"; };
 		072224AB783F1D0A7644D42B0FC6E812 /* WCTError.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTError.h; path = objc/WCDB/interface/statictics/WCTError.h; sourceTree = "<group>"; };
@@ -1503,7 +1504,7 @@
 		07AAF8AA6147F4AB0258F9006E3F2E31 /* MASLayoutConstraint.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MASLayoutConstraint.h; path = Masonry/MASLayoutConstraint.h; sourceTree = "<group>"; };
 		07D610F0092A643DC57278799DD076AE /* SDDiskCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDDiskCache.h; path = SDWebImage/Core/SDDiskCache.h; sourceTree = "<group>"; };
 		07D98F28808CAC4DBF91F066D45555E0 /* NSArray+YCTools.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSArray+YCTools.h"; path = "YCEasyTool/Classes/CollectionTools/NSArray+YCTools.h"; sourceTree = "<group>"; };
-		086848A1218F702A2556F13561EE6C64 /* sqliterk_util.c */ = {isa = PBXFileReference; includeInIndex = 1; name = sqliterk_util.c; path = repair/sqliterk_util.c; sourceTree = "<group>"; };
+		086848A1218F702A2556F13561EE6C64 /* sqliterk_util.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = sqliterk_util.c; path = repair/sqliterk_util.c; sourceTree = "<group>"; };
 		087AC93DB1371FDDA42ACFF4CF71E220 /* SDWebImageOptionsProcessor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDWebImageOptionsProcessor.h; path = SDWebImage/Core/SDWebImageOptionsProcessor.h; sourceTree = "<group>"; };
 		08861D55F0C7DEB73D120D4BA961FDB7 /* Pods-EulixSpaceTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-EulixSpaceTests-acknowledgements.plist"; sourceTree = "<group>"; };
 		08D889A1833E11F59EFADDF5CD64E28F /* WCTDatabase+File.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTDatabase+File.h"; path = "objc/WCDB/interface/database/WCTDatabase+File.h"; sourceTree = "<group>"; };
@@ -1518,21 +1519,21 @@
 		0AD83435ABECBAD1387D30218A330FBE /* SAMKeychain-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SAMKeychain-prefix.pch"; sourceTree = "<group>"; };
 		0AF654F53A3613303027EDF4A4446D72 /* YCItemDefine.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCItemDefine.h; path = YCBase/Classes/YCItemDefine.h; sourceTree = "<group>"; };
 		0B2A6A0D0349E583E98CE034D6E70CBE /* statement_recyclable.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_recyclable.cpp; path = objc/WCDB/core/statement_recyclable.cpp; sourceTree = "<group>"; };
-		0B2BA4641C180D2965DAF4B72EE9AE34 /* WCDB */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = WCDB; path = libWCDB.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		0B2BA4641C180D2965DAF4B72EE9AE34 /* libWCDB.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libWCDB.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		0B48E266DC00D07EF7BAC9547E65B88A /* WCTSelect+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTSelect+Private.h"; path = "objc/WCDB/interface/chaincall/WCTSelect+Private.h"; sourceTree = "<group>"; };
 		0B663AC856DEFC68994DDC74C6498F36 /* WCTError+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTError+Private.h"; path = "objc/WCDB/interface/statictics/WCTError+Private.h"; sourceTree = "<group>"; };
 		0BAD5CF7883C3BA3343B43FF4F3A616D /* mz_strm_wzaes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mz_strm_wzaes.h; path = SSZipArchive/minizip/mz_strm_wzaes.h; sourceTree = "<group>"; };
 		0BBCCE9F9E6E8A7148356B791C35FBDB /* MJExtension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MJExtension.h; path = MJExtension/MJExtension.h; sourceTree = "<group>"; };
 		0BE855CF218A14DE3CF2F29CE2B64B82 /* CocoaLumberjack-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CocoaLumberjack-dummy.m"; sourceTree = "<group>"; };
-		0C00A87C715E5D9F528ACB763321489E /* WCTUpdate.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTUpdate.mm; path = objc/WCDB/interface/chaincall/WCTUpdate.mm; sourceTree = "<group>"; };
-		0C2F90183A14452C7B345C7D8539E63C /* mz_strm_zlib.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mz_strm_zlib.c; path = SSZipArchive/minizip/mz_strm_zlib.c; sourceTree = "<group>"; };
+		0C00A87C715E5D9F528ACB763321489E /* WCTUpdate.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTUpdate.mm; path = objc/WCDB/interface/chaincall/WCTUpdate.mm; sourceTree = "<group>"; };
+		0C2F90183A14452C7B345C7D8539E63C /* mz_strm_zlib.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mz_strm_zlib.c; path = SSZipArchive/minizip/mz_strm_zlib.c; sourceTree = "<group>"; };
 		0CF38FB3F421720CA02B9E2081FAC0F8 /* sqliterk.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sqliterk.h; path = repair/sqliterk.h; sourceTree = "<group>"; };
 		0D425317D7A6D3438BD54CE27695192C /* AFNetworking.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = AFNetworking.debug.xcconfig; sourceTree = "<group>"; };
 		0D7CC8C724652F136F6303C19CC8DC45 /* SDMemoryCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDMemoryCache.h; path = SDWebImage/Core/SDMemoryCache.h; sourceTree = "<group>"; };
 		0D7CD697AEEC10B8DB808EE9C6C87AFF /* SDImageAPNGCoder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDImageAPNGCoder.h; path = SDWebImage/Core/SDImageAPNGCoder.h; sourceTree = "<group>"; };
 		0E281A463831C24B7EDCEEDF1401A5D7 /* YCEasyTool.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = YCEasyTool.debug.xcconfig; sourceTree = "<group>"; };
 		0E8944126B492E957C9EDF79939B4724 /* SRRandom.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SRRandom.m; path = SocketRocket/Internal/Utilities/SRRandom.m; sourceTree = "<group>"; };
-		0F65D5A34C985EE6F259A7117D798DCC /* mz_os_posix.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mz_os_posix.c; path = SSZipArchive/minizip/mz_os_posix.c; sourceTree = "<group>"; };
+		0F65D5A34C985EE6F259A7117D798DCC /* mz_os_posix.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mz_os_posix.c; path = SSZipArchive/minizip/mz_os_posix.c; sourceTree = "<group>"; };
 		0FDF87CD657A2C6B115742AD0208795C /* sqlite3ext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sqlite3ext.h; path = src/sqlite3ext.h; sourceTree = "<group>"; };
 		10121666C46E0C86145DD30D240065F8 /* literal_value.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = literal_value.cpp; path = objc/WCDB/abstract/literal_value.cpp; sourceTree = "<group>"; };
 		1037BCA219693FBF4A63D18D4CF7A8D7 /* GCDWebServerResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GCDWebServerResponse.h; path = GCDWebServer/Core/GCDWebServerResponse.h; sourceTree = "<group>"; };
@@ -1561,7 +1562,7 @@
 		155623D977A5F5ECAA45C9A9C37AD386 /* statement_update.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_update.cpp; path = objc/WCDB/abstract/statement_update.cpp; sourceTree = "<group>"; };
 		1559598D39971906AB47CA75683C9387 /* CALayer+Compat.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "CALayer+Compat.m"; path = "lottie-ios/Classes/MacCompatibility/CALayer+Compat.m"; sourceTree = "<group>"; };
 		157FB2E5E3691EDFADDA684986723473 /* column_type.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = column_type.cpp; path = objc/WCDB/abstract/column_type.cpp; sourceTree = "<group>"; };
-		15C3749F43420B61BB1CE7A65720712E /* WCTStatistics+Compatible.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTStatistics+Compatible.mm"; path = "objc/WCDB/interface/compatible/WCTStatistics+Compatible.mm"; sourceTree = "<group>"; };
+		15C3749F43420B61BB1CE7A65720712E /* WCTStatistics+Compatible.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTStatistics+Compatible.mm"; path = "objc/WCDB/interface/compatible/WCTStatistics+Compatible.mm"; sourceTree = "<group>"; };
 		1616D34563B21F8738DFACF82FB4520F /* SAMKeychain.bundle */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "wrapper.plug-in"; name = SAMKeychain.bundle; path = Support/SAMKeychain.bundle; sourceTree = "<group>"; };
 		1631B85BA084316DFC53EA872AF12DE9 /* UIImage+Metadata.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Metadata.m"; path = "SDWebImage/Core/UIImage+Metadata.m"; sourceTree = "<group>"; };
 		16524DDFC80E3A9067463800C876874B /* SVRadialGradientLayer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SVRadialGradientLayer.h; path = SVProgressHUD/SVRadialGradientLayer.h; sourceTree = "<group>"; };
@@ -1574,12 +1575,12 @@
 		18E726D6F3A881C8DAB32AE45EFBCE12 /* order_term.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = order_term.hpp; path = objc/WCDB/abstract/order_term.hpp; sourceTree = "<group>"; };
 		18EC952ABA252B7770E2446F77949E6F /* JSONValueTransformer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = JSONValueTransformer.h; path = JSONModel/JSONModelTransformations/JSONValueTransformer.h; sourceTree = "<group>"; };
 		18F2E43A745AADC70C4921E7DC014B30 /* MJPropertyType.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MJPropertyType.m; path = MJExtension/MJPropertyType.m; sourceTree = "<group>"; };
-		191D301B5864CAB77678211CBBE42218 /* vdbe.c */ = {isa = PBXFileReference; includeInIndex = 1; name = vdbe.c; path = src/vdbe.c; sourceTree = "<group>"; };
+		191D301B5864CAB77678211CBBE42218 /* vdbe.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = vdbe.c; path = src/vdbe.c; sourceTree = "<group>"; };
 		1A29DD7FD9E51AF8D254E72674B9A633 /* NSBezierPath+SDRoundedCorners.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSBezierPath+SDRoundedCorners.h"; path = "SDWebImage/Private/NSBezierPath+SDRoundedCorners.h"; sourceTree = "<group>"; };
 		1AB4C2E209DE3980B24B7EA8841AC964 /* mz_compat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mz_compat.h; path = SSZipArchive/minizip/mz_compat.h; sourceTree = "<group>"; };
 		1AFFC46DB3B471AFF52FC778FE9ECA20 /* Reachability.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Reachability.release.xcconfig; sourceTree = "<group>"; };
 		1B14F6971DE98C2710F13056A7C1B312 /* column.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = column.cpp; path = objc/WCDB/abstract/column.cpp; sourceTree = "<group>"; };
-		1BA5C54018B60CFC811BF69AC03E5190 /* fts3_tokenize_vtab.c */ = {isa = PBXFileReference; includeInIndex = 1; name = fts3_tokenize_vtab.c; path = ext/fts3/fts3_tokenize_vtab.c; sourceTree = "<group>"; };
+		1BA5C54018B60CFC811BF69AC03E5190 /* fts3_tokenize_vtab.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fts3_tokenize_vtab.c; path = ext/fts3/fts3_tokenize_vtab.c; sourceTree = "<group>"; };
 		1BA820DBD243460D30E92E9CA0A53F83 /* SDImageTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDImageTransformer.m; path = SDWebImage/Core/SDImageTransformer.m; sourceTree = "<group>"; };
 		1BB97A33946D110C3D570022CDB743AF /* SDWebImageDownloader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDWebImageDownloader.m; path = SDWebImage/Core/SDWebImageDownloader.m; sourceTree = "<group>"; };
 		1BF8B0379AD9806D20F6267F30732C0C /* statement_attach.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = statement_attach.hpp; path = objc/WCDB/abstract/statement_attach.hpp; sourceTree = "<group>"; };
@@ -1593,69 +1594,69 @@
 		1D02C4B84CC0298B822C0CE22F1D7A13 /* WCTRowSelect.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTRowSelect.h; path = objc/WCDB/interface/chaincall/WCTRowSelect.h; sourceTree = "<group>"; };
 		1D0E3499651C20EEE30404732FA80533 /* NSObject+MJProperty.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+MJProperty.h"; path = "MJExtension/NSObject+MJProperty.h"; sourceTree = "<group>"; };
 		1D1876E88D239AD8E644BDB042B6E2F3 /* SVProgressHUD.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SVProgressHUD.debug.xcconfig; sourceTree = "<group>"; };
-		1D1EE0A5DD6B1D6CD419CCE7E6E11F31 /* utf.c */ = {isa = PBXFileReference; includeInIndex = 1; name = utf.c; path = src/utf.c; sourceTree = "<group>"; };
+		1D1EE0A5DD6B1D6CD419CCE7E6E11F31 /* utf.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = utf.c; path = src/utf.c; sourceTree = "<group>"; };
 		1D6CA39776E3854DE5506DFDBEFB990D /* handle_pool.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = handle_pool.hpp; path = objc/WCDB/core/handle_pool.hpp; sourceTree = "<group>"; };
-		1D88205AE5C48E9A6183FB6901F3262B /* select.c */ = {isa = PBXFileReference; includeInIndex = 1; name = select.c; path = src/select.c; sourceTree = "<group>"; };
+		1D88205AE5C48E9A6183FB6901F3262B /* select.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = select.c; path = src/select.c; sourceTree = "<group>"; };
 		1D8B79ED96A77F44EAC14E0A4361F17F /* config.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = config.cpp; path = objc/WCDB/core/config.cpp; sourceTree = "<group>"; };
 		1D91DA7B37125377A69797FE409F67B2 /* DDFileLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDFileLogger.m; path = Sources/CocoaLumberjack/DDFileLogger.m; sourceTree = "<group>"; };
 		1DDCB916C80273ED91042DE217D5C111 /* Masonry.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Masonry.debug.xcconfig; sourceTree = "<group>"; };
-		1DF9338B63AE57B5996204C553C12CDF /* fts3.c */ = {isa = PBXFileReference; includeInIndex = 1; name = fts3.c; path = ext/fts3/fts3.c; sourceTree = "<group>"; };
+		1DF9338B63AE57B5996204C553C12CDF /* fts3.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fts3.c; path = ext/fts3/fts3.c; sourceTree = "<group>"; };
 		1E482B2F19BE33C1DDC2AAD2C4197D0A /* statement_drop_table.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = statement_drop_table.hpp; path = objc/WCDB/abstract/statement_drop_table.hpp; sourceTree = "<group>"; };
-		1E4B2578ADF6450B989B2FD9B8033A24 /* WCTAnyProperty.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTAnyProperty.mm; path = objc/WCDB/interface/orm/coding/WCTAnyProperty.mm; sourceTree = "<group>"; };
+		1E4B2578ADF6450B989B2FD9B8033A24 /* WCTAnyProperty.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTAnyProperty.mm; path = objc/WCDB/interface/orm/coding/WCTAnyProperty.mm; sourceTree = "<group>"; };
 		1E5F93E9F5710A334DFEBACC9EC7FEFC /* LOTAnimationCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTAnimationCache.m; path = "lottie-ios/Classes/Private/LOTAnimationCache.m"; sourceTree = "<group>"; };
 		1E7D128BDA6F4A6F5DBFA989F216120D /* statement_create_virtual_table.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_create_virtual_table.cpp; path = objc/WCDB/abstract/statement_create_virtual_table.cpp; sourceTree = "<group>"; };
 		1EB39E73565F111F9EF5DFD301F3FD8E /* mz_zip_rw.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mz_zip_rw.h; path = SSZipArchive/minizip/mz_zip_rw.h; sourceTree = "<group>"; };
 		1EF3A04D90C1247D87BFEBAFA6B7D137 /* WCTTransaction+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTTransaction+Private.h"; path = "objc/WCDB/interface/transaction/WCTTransaction+Private.h"; sourceTree = "<group>"; };
 		1F1C9D563C8AC89059A3441C9FE8B670 /* SDImageAssetManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDImageAssetManager.h; path = SDWebImage/Private/SDImageAssetManager.h; sourceTree = "<group>"; };
 		1F2694A99BD3FA551EBC6D2F28BDF2B2 /* GCDWebServerFunctions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GCDWebServerFunctions.h; path = GCDWebServer/Core/GCDWebServerFunctions.h; sourceTree = "<group>"; };
-		1F495311372D181AC283F7F48F8659C4 /* WCTExpr.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTExpr.mm; path = objc/WCDB/interface/orm/coding/WCTExpr.mm; sourceTree = "<group>"; };
+		1F495311372D181AC283F7F48F8659C4 /* WCTExpr.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTExpr.mm; path = objc/WCDB/interface/orm/coding/WCTExpr.mm; sourceTree = "<group>"; };
 		1F5A518DC4443A312BB1E53D3D9E21BA /* FileMD5Hash.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FileMD5Hash.release.xcconfig; sourceTree = "<group>"; };
 		1F62AB7A29D048DFEA29322B3257DCA3 /* YCCollectionViewDefine.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCCollectionViewDefine.h; path = YCEasyTool/Classes/UI/CollectionView/YCCollectionViewDefine.h; sourceTree = "<group>"; };
 		1FCC5AA1F05078A555FAF8BB7F0A1E63 /* YCPollingEntity.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCPollingEntity.h; path = YCEasyTool/Classes/PollingEntity/YCPollingEntity.h; sourceTree = "<group>"; };
-		1FFED36A657123030ABB700256D73F15 /* Masonry */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = Masonry; path = libMasonry.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		1FFED36A657123030ABB700256D73F15 /* libMasonry.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMasonry.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		202D79E02BA405D14BF8715130C98F77 /* CALayer+Compat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "CALayer+Compat.h"; path = "lottie-ios/Classes/MacCompatibility/CALayer+Compat.h"; sourceTree = "<group>"; };
 		2041A5857F0D28762F58178A71B3F1F0 /* LOTShapeStar.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTShapeStar.h; path = "lottie-ios/Classes/Models/LOTShapeStar.h"; sourceTree = "<group>"; };
-		209D8FFAB3217F619A07DEF66D66FE81 /* NSString+WCTColumnCoding.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "NSString+WCTColumnCoding.mm"; path = "objc/WCDB/interface/builtin/NSString+WCTColumnCoding.mm"; sourceTree = "<group>"; };
-		20F79DD10EEE3BD5DDA7827278C0BBB6 /* WCTDatabase+Statistics.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTDatabase+Statistics.mm"; path = "objc/WCDB/interface/statictics/WCTDatabase+Statistics.mm"; sourceTree = "<group>"; };
+		209D8FFAB3217F619A07DEF66D66FE81 /* NSString+WCTColumnCoding.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSString+WCTColumnCoding.mm"; path = "objc/WCDB/interface/builtin/NSString+WCTColumnCoding.mm"; sourceTree = "<group>"; };
+		20F79DD10EEE3BD5DDA7827278C0BBB6 /* WCTDatabase+Statistics.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTDatabase+Statistics.mm"; path = "objc/WCDB/interface/statictics/WCTDatabase+Statistics.mm"; sourceTree = "<group>"; };
 		210993801BBCCB5D3A97FE946B3AAA43 /* CocoaLumberjack.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CocoaLumberjack.debug.xcconfig; sourceTree = "<group>"; };
 		210E7CC4B11039B267968149DD99C657 /* mz_crypt.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mz_crypt.h; path = SSZipArchive/minizip/mz_crypt.h; sourceTree = "<group>"; };
 		2139EA513520F8416548BB59A20FA6BD /* WCTStatistics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTStatistics.h; path = objc/WCDB/interface/statictics/WCTStatistics.h; sourceTree = "<group>"; };
-		2157B3C425CDA726CF77EA87D4B5154D /* OpenSSL.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; name = OpenSSL.xcframework; path = Frameworks/OpenSSL.xcframework; sourceTree = "<group>"; };
+		2157B3C425CDA726CF77EA87D4B5154D /* OpenSSL.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = OpenSSL.xcframework; path = Frameworks/OpenSSL.xcframework; sourceTree = "<group>"; };
 		217ECFD38145889883CF2FC0F9454784 /* FLAnimatedImage-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FLAnimatedImage-dummy.m"; sourceTree = "<group>"; };
 		21AA9B93A1069AF4FD83EB1F23208B19 /* WCTSequence.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTSequence.h; path = objc/WCDB/interface/builtin/WCTSequence.h; sourceTree = "<group>"; };
-		22D2B01633E04C2AE3B17850B97C34BE /* WCTInsert.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTInsert.mm; path = objc/WCDB/interface/chaincall/WCTInsert.mm; sourceTree = "<group>"; };
+		22D2B01633E04C2AE3B17850B97C34BE /* WCTInsert.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTInsert.mm; path = objc/WCDB/interface/chaincall/WCTInsert.mm; sourceTree = "<group>"; };
 		2322954994B5F4CB3C422FD2914A192D /* YCCollectionViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCCollectionViewController.h; path = YCBase/Classes/YCCollectionViewController.h; sourceTree = "<group>"; };
 		232EA5950B9DBC2DE125CBE62E507179 /* SDWebImageDownloader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDWebImageDownloader.h; path = SDWebImage/Core/SDWebImageDownloader.h; sourceTree = "<group>"; };
 		233C79FD38587DDE43D5BC38EBF63C3C /* handle_statement.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = handle_statement.hpp; path = objc/WCDB/abstract/handle_statement.hpp; sourceTree = "<group>"; };
-		236EAD8BA95C99035E20C49FE0653303 /* rowset.c */ = {isa = PBXFileReference; includeInIndex = 1; name = rowset.c; path = src/rowset.c; sourceTree = "<group>"; };
+		236EAD8BA95C99035E20C49FE0653303 /* rowset.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = rowset.c; path = src/rowset.c; sourceTree = "<group>"; };
 		23EE708AC1245F27135B2D599BB350C1 /* LOTShapeStar.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTShapeStar.m; path = "lottie-ios/Classes/Models/LOTShapeStar.m"; sourceTree = "<group>"; };
 		2410A09CD41F6914319CD5810671F58A /* WCTRuntimeObjCAccessor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTRuntimeObjCAccessor.h; path = objc/WCDB/interface/orm/accessor/WCTRuntimeObjCAccessor.h; sourceTree = "<group>"; };
 		242C7D340E148077E955275FB34E9DE4 /* UIImage+ForceDecode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+ForceDecode.h"; path = "SDWebImage/Core/UIImage+ForceDecode.h"; sourceTree = "<group>"; };
-		244BCBC44F0854857E5DD4AF3C5FA1CE /* mem0.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mem0.c; path = src/mem0.c; sourceTree = "<group>"; };
-		24529152C2D81EB178504DA292DAB890 /* WCTRuntimeObjCAccessor.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTRuntimeObjCAccessor.mm; path = objc/WCDB/interface/orm/accessor/WCTRuntimeObjCAccessor.mm; sourceTree = "<group>"; };
+		244BCBC44F0854857E5DD4AF3C5FA1CE /* mem0.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mem0.c; path = src/mem0.c; sourceTree = "<group>"; };
+		24529152C2D81EB178504DA292DAB890 /* WCTRuntimeObjCAccessor.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTRuntimeObjCAccessor.mm; path = objc/WCDB/interface/orm/accessor/WCTRuntimeObjCAccessor.mm; sourceTree = "<group>"; };
 		25714E84DBB04E2C3F54D551C85286BD /* SRWebSocket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SRWebSocket.h; path = SocketRocket/SRWebSocket.h; sourceTree = "<group>"; };
-		259517CA1544CF71D2B84315F71880F3 /* WCTTransaction.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTTransaction.mm; path = objc/WCDB/interface/transaction/WCTTransaction.mm; sourceTree = "<group>"; };
-		25983CFB5D26FAFF860140493FC35E1B /* vdbeapi.c */ = {isa = PBXFileReference; includeInIndex = 1; name = vdbeapi.c; path = src/vdbeapi.c; sourceTree = "<group>"; };
-		25A43D24969E10E8C3C0D50B7690DE0E /* WCTTransaction+Statistics.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTTransaction+Statistics.mm"; path = "objc/WCDB/interface/statictics/WCTTransaction+Statistics.mm"; sourceTree = "<group>"; };
+		259517CA1544CF71D2B84315F71880F3 /* WCTTransaction.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTTransaction.mm; path = objc/WCDB/interface/transaction/WCTTransaction.mm; sourceTree = "<group>"; };
+		25983CFB5D26FAFF860140493FC35E1B /* vdbeapi.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = vdbeapi.c; path = src/vdbeapi.c; sourceTree = "<group>"; };
+		25A43D24969E10E8C3C0D50B7690DE0E /* WCTTransaction+Statistics.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTTransaction+Statistics.mm"; path = "objc/WCDB/interface/statictics/WCTTransaction+Statistics.mm"; sourceTree = "<group>"; };
 		25D106DE617ABBA91F4DE9B7C6813B85 /* WCTIndexMacro.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTIndexMacro.h; path = objc/WCDB/interface/orm/macro/WCTIndexMacro.h; sourceTree = "<group>"; };
 		26288C14BC4C34D409B12A5D82541CFF /* column_index.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = column_index.cpp; path = objc/WCDB/abstract/column_index.cpp; sourceTree = "<group>"; };
-		263690AE2710431201F790EF1EF28C96 /* WCTDatabase+Compatible.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTDatabase+Compatible.mm"; path = "objc/WCDB/interface/compatible/WCTDatabase+Compatible.mm"; sourceTree = "<group>"; };
+		263690AE2710431201F790EF1EF28C96 /* WCTDatabase+Compatible.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTDatabase+Compatible.mm"; path = "objc/WCDB/interface/compatible/WCTDatabase+Compatible.mm"; sourceTree = "<group>"; };
 		26806558B1E2B73B6F7A0EE219308BB0 /* YYCache-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "YYCache-dummy.m"; sourceTree = "<group>"; };
 		26E08BAD588E7F3ED4F29815053D72EB /* mz_zip.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mz_zip.h; path = SSZipArchive/minizip/mz_zip.h; sourceTree = "<group>"; };
 		2731B929083F26D80F3C66A7DC72FE63 /* LOTPolystarAnimator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTPolystarAnimator.m; path = "lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPolystarAnimator.m"; sourceTree = "<group>"; };
 		280F7C2BD52C090FA21EA29CA5B3269F /* JSONModel+networking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "JSONModel+networking.m"; path = "JSONModel/JSONModelNetworking/JSONModel+networking.m"; sourceTree = "<group>"; };
 		2839F8D782DD4E117AED5624D3296D46 /* Reachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Reachability.m; sourceTree = "<group>"; };
 		286960C0CF8B0465BE5791FA7630E42F /* LOTSizeInterpolator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTSizeInterpolator.h; path = "lottie-ios/Classes/RenderSystem/InterpolatorNodes/LOTSizeInterpolator.h"; sourceTree = "<group>"; };
-		287875A0B2464E74FEA1F211C5C586E5 /* YCEasyTool */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = YCEasyTool; path = libYCEasyTool.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		287875A0B2464E74FEA1F211C5C586E5 /* libYCEasyTool.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libYCEasyTool.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		2985778B0D6D90EBB60DFB7916F26185 /* UIButton+WebCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+WebCache.h"; path = "SDWebImage/Core/UIButton+WebCache.h"; sourceTree = "<group>"; };
 		298CA3DB17DEAE70A965E534D9355176 /* DDFileLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDFileLogger.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h; sourceTree = "<group>"; };
 		29ABFE2285822C9B50C9D17A713BB1C8 /* SDWebImageCacheKeyFilter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDWebImageCacheKeyFilter.h; path = SDWebImage/Core/SDWebImageCacheKeyFilter.h; sourceTree = "<group>"; };
-		29B4C11ED578BA9280A0577EB5E8F534 /* fts3_hash.c */ = {isa = PBXFileReference; includeInIndex = 1; name = fts3_hash.c; path = ext/fts3/fts3_hash.c; sourceTree = "<group>"; };
+		29B4C11ED578BA9280A0577EB5E8F534 /* fts3_hash.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fts3_hash.c; path = ext/fts3/fts3_hash.c; sourceTree = "<group>"; };
 		2A1A25D3041CE596B0D1AF105F3B9077 /* LOTRenderGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTRenderGroup.h; path = "lottie-ios/Classes/RenderSystem/RenderNodes/LOTRenderGroup.h"; sourceTree = "<group>"; };
-		2A479E932E481AAD78FE3527A557E464 /* trigger.c */ = {isa = PBXFileReference; includeInIndex = 1; name = trigger.c; path = src/trigger.c; sourceTree = "<group>"; };
+		2A479E932E481AAD78FE3527A557E464 /* trigger.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = trigger.c; path = src/trigger.c; sourceTree = "<group>"; };
 		2ABE88122905489471BD40D12BCDF267 /* SRLog.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SRLog.m; path = SocketRocket/Internal/Utilities/SRLog.m; sourceTree = "<group>"; };
-		2ACC75C5C25624D6D7EBDE94A6624753 /* complete.c */ = {isa = PBXFileReference; includeInIndex = 1; name = complete.c; path = src/complete.c; sourceTree = "<group>"; };
-		2B276B0A79173A1D6E83C9B4FB9A4A57 /* MJExtension */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = MJExtension; path = libMJExtension.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		2ACC75C5C25624D6D7EBDE94A6624753 /* complete.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = complete.c; path = src/complete.c; sourceTree = "<group>"; };
+		2B276B0A79173A1D6E83C9B4FB9A4A57 /* libMJExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMJExtension.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B9380A36ECE67D0FB9CD5E0015D261A /* subquery.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = subquery.cpp; path = objc/WCDB/abstract/subquery.cpp; sourceTree = "<group>"; };
 		2BD34D1E56CFB48533E1E9ACFB8DBCE6 /* IQNSArray+Sort.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "IQNSArray+Sort.h"; path = "IQKeyboardManager/Categories/IQNSArray+Sort.h"; sourceTree = "<group>"; };
 		2BFD58F28713299BBE5C90D85AA39D1F /* WCTDatabase+Database.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTDatabase+Database.h"; path = "objc/WCDB/interface/database/WCTDatabase+Database.h"; sourceTree = "<group>"; };
@@ -1672,7 +1673,7 @@
 		2EA65FDA6D482A6E616DEC1711ADC60C /* rtree.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = rtree.h; path = ext/rtree/rtree.h; sourceTree = "<group>"; };
 		2F0ADF2985376123BC7E46591C2B6569 /* pcache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = pcache.h; path = src/pcache.h; sourceTree = "<group>"; };
 		2F43D242B3DD3D6BF17C817B10EA008F /* GCDWebServerFunctions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = GCDWebServerFunctions.m; path = GCDWebServer/Core/GCDWebServerFunctions.m; sourceTree = "<group>"; };
-		301ACD0F926702246EF68212B155888E /* WCTChainCall+Statistics.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTChainCall+Statistics.mm"; path = "objc/WCDB/interface/statictics/WCTChainCall+Statistics.mm"; sourceTree = "<group>"; };
+		301ACD0F926702246EF68212B155888E /* WCTChainCall+Statistics.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTChainCall+Statistics.mm"; path = "objc/WCDB/interface/statictics/WCTChainCall+Statistics.mm"; sourceTree = "<group>"; };
 		3035C6B9F7E77597E61AA83A5B00AC7F /* SRConstants.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SRConstants.m; path = SocketRocket/Internal/SRConstants.m; sourceTree = "<group>"; };
 		3076F756CAA4D91E168182E05C9C9FA0 /* recyclable.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = recyclable.hpp; path = objc/WCDB/util/recyclable.hpp; sourceTree = "<group>"; };
 		309B3D85222A2AF37273794CDEF8882A /* ISO8601-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ISO8601-dummy.m"; sourceTree = "<group>"; };
@@ -1684,7 +1685,7 @@
 		31CCFDF4ED81845DE9FA96003B7F2AF8 /* UIImage+Transform.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Transform.h"; path = "SDWebImage/Core/UIImage+Transform.h"; sourceTree = "<group>"; };
 		31E4F7C7E8A8DCF4C6A32E3154AA2792 /* YCSegmentItem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCSegmentItem.h; path = YCEasyTool/Classes/UI/Segment/YCSegmentItem.h; sourceTree = "<group>"; };
 		3234430BF64C530BD32E7F899A1CD1D9 /* Pods-EulixSpace-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-EulixSpace-acknowledgements.plist"; sourceTree = "<group>"; };
-		326220419BF02F0173C355F0D90103C5 /* WCTSelectBase.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTSelectBase.mm; path = objc/WCDB/interface/chaincall/WCTSelectBase.mm; sourceTree = "<group>"; };
+		326220419BF02F0173C355F0D90103C5 /* WCTSelectBase.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTSelectBase.mm; path = objc/WCDB/interface/chaincall/WCTSelectBase.mm; sourceTree = "<group>"; };
 		32800A1B8171553F8431207FB9A55EF5 /* UIBezierPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = UIBezierPath.h; path = "lottie-ios/Classes/MacCompatibility/UIBezierPath.h"; sourceTree = "<group>"; };
 		32CB2DD038E67B56ABEC5F7D9B1CFB3D /* ISO8601.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ISO8601.debug.xcconfig; sourceTree = "<group>"; };
 		32F01053B8A26A9B13CE175815665EBA /* GCDWebServerErrorResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GCDWebServerErrorResponse.h; path = GCDWebServer/Responses/GCDWebServerErrorResponse.h; sourceTree = "<group>"; };
@@ -1699,7 +1700,7 @@
 		33EC8AFC183E8AB6F61B38E1B1A475FD /* JSONModelClassProperty.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = JSONModelClassProperty.m; path = JSONModel/JSONModel/JSONModelClassProperty.m; sourceTree = "<group>"; };
 		34678FC5FF2BCD8B359E7243F930C474 /* expr.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = expr.hpp; path = objc/WCDB/abstract/expr.hpp; sourceTree = "<group>"; };
 		34EAD459BBF954E925A7143B7CFD2089 /* SDGraphicsImageRenderer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDGraphicsImageRenderer.m; path = SDWebImage/Core/SDGraphicsImageRenderer.m; sourceTree = "<group>"; };
-		352656B2716278147F3FF724D9B22995 /* insert.c */ = {isa = PBXFileReference; includeInIndex = 1; name = insert.c; path = src/insert.c; sourceTree = "<group>"; };
+		352656B2716278147F3FF724D9B22995 /* insert.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = insert.c; path = src/insert.c; sourceTree = "<group>"; };
 		3624F7523047364B1F17B21650A4E782 /* LOTAnimationView_Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTAnimationView_Internal.h; path = "lottie-ios/Classes/Private/LOTAnimationView_Internal.h"; sourceTree = "<group>"; };
 		3638FB0FB434F64876380C8869F54135 /* mutex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mutex.h; path = src/mutex.h; sourceTree = "<group>"; };
 		363BA9500DCFC356D90CD891FF83CD6B /* WCTTransaction+Table.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTTransaction+Table.h"; path = "objc/WCDB/interface/table/WCTTransaction+Table.h"; sourceTree = "<group>"; };
@@ -1719,7 +1720,7 @@
 		38B27E801219193043B6586E62F2DCA6 /* YCProperty.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = YCProperty.m; path = YCEasyTool/Classes/Property/YCProperty.m; sourceTree = "<group>"; };
 		390CA960A444EDB8BF94D96BC06C674D /* SVProgressAnimatedView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SVProgressAnimatedView.m; path = SVProgressHUD/SVProgressAnimatedView.m; sourceTree = "<group>"; };
 		39294F991037CFC45EAFB8E29ACF882D /* YYModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YYModel.h; path = YYModel/YYModel.h; sourceTree = "<group>"; };
-		3959167B884243E045A646FAB47A70DE /* sqliterk_values.c */ = {isa = PBXFileReference; includeInIndex = 1; name = sqliterk_values.c; path = repair/sqliterk_values.c; sourceTree = "<group>"; };
+		3959167B884243E045A646FAB47A70DE /* sqliterk_values.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = sqliterk_values.c; path = repair/sqliterk_values.c; sourceTree = "<group>"; };
 		399AA87247925DD1C2A8A9AAA6D38080 /* SDWebImageTransition.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDWebImageTransition.h; path = SDWebImage/Core/SDWebImageTransition.h; sourceTree = "<group>"; };
 		3A7AB2AD63541577BF9673459EC250AF /* Pods-EulixSpaceTests.platform.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EulixSpaceTests.platform.xcconfig"; sourceTree = "<group>"; };
 		3AC85E6972500D7CA64B0D99AA00895D /* ticker.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = ticker.hpp; path = objc/WCDB/util/ticker.hpp; sourceTree = "<group>"; };
@@ -1730,7 +1731,7 @@
 		3B31B51A5949D9025A179EBF3894EF07 /* YCTabBar.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = YCTabBar.m; path = YCEasyTool/Classes/UI/TabBarController/YCTabBar.m; sourceTree = "<group>"; };
 		3BFBABAE5ED0AA5AE94FA31C0544E948 /* conflict.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = conflict.cpp; path = objc/WCDB/abstract/conflict.cpp; sourceTree = "<group>"; };
 		3C068965CE4B7721895ED11CCB828D26 /* MJExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = MJExtension.debug.xcconfig; sourceTree = "<group>"; };
-		3C0F93CAC9247F5AECB6D03642894B8A /* wherecode.c */ = {isa = PBXFileReference; includeInIndex = 1; name = wherecode.c; path = src/wherecode.c; sourceTree = "<group>"; };
+		3C0F93CAC9247F5AECB6D03642894B8A /* wherecode.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = wherecode.c; path = src/wherecode.c; sourceTree = "<group>"; };
 		3C2B33140EB0850239285B424474B3A3 /* Pods-EulixSpaceTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-EulixSpaceTests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		3C9C882647EBF1AB607A596C73CAF38A /* WCTChainCall.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTChainCall.h; path = objc/WCDB/interface/chaincall/WCTChainCall.h; sourceTree = "<group>"; };
 		3CA8124869893899ABA83DC844D49AA0 /* pragma.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = pragma.h; path = src/pragma.h; sourceTree = "<group>"; };
@@ -1738,32 +1739,32 @@
 		3D234E7B10864B586548302C291037B4 /* FileMD5Hash-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FileMD5Hash-dummy.m"; sourceTree = "<group>"; };
 		3D2598C98A5BB7881E1A45725FF92743 /* SDWebImageCompat.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDWebImageCompat.m; path = SDWebImage/Core/SDWebImageCompat.m; sourceTree = "<group>"; };
 		3D46C92430CF26AAB1AE32C12D237B21 /* GKPhotoBrowser.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = GKPhotoBrowser.release.xcconfig; sourceTree = "<group>"; };
-		3D4F59CE470862391B1ED48696A06C54 /* mem5.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mem5.c; path = src/mem5.c; sourceTree = "<group>"; };
+		3D4F59CE470862391B1ED48696A06C54 /* mem5.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mem5.c; path = src/mem5.c; sourceTree = "<group>"; };
 		3D899E2C705E8615F562FF41A1405FF9 /* DDLegacyMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDLegacyMacros.h; path = "Sources/CocoaLumberjack/Supporting Files/DDLegacyMacros.h"; sourceTree = "<group>"; };
-		3D99186630A313BCE17BAA051E0E2E19 /* mz_zip_rw.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mz_zip_rw.c; path = SSZipArchive/minizip/mz_zip_rw.c; sourceTree = "<group>"; };
+		3D99186630A313BCE17BAA051E0E2E19 /* mz_zip_rw.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mz_zip_rw.c; path = SSZipArchive/minizip/mz_zip_rw.c; sourceTree = "<group>"; };
 		3D9CCBA60ECA18E30B4C1381CA805CF9 /* Pods-EulixSpace.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EulixSpace.appstore.xcconfig"; sourceTree = "<group>"; };
 		3E11E3301D1E7E6812D7730774B8C292 /* sqliterk_os.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sqliterk_os.h; path = repair/sqliterk_os.h; sourceTree = "<group>"; };
-		3EB929E1E030682A2A820461CB035876 /* WCTPropertyBase.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTPropertyBase.mm; path = objc/WCDB/interface/orm/coding/WCTPropertyBase.mm; sourceTree = "<group>"; };
-		3EC658789D70ADEB42135D2DF4F18A4D /* WCTColumnBinding.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTColumnBinding.mm; path = objc/WCDB/interface/orm/binding/WCTColumnBinding.mm; sourceTree = "<group>"; };
+		3EB929E1E030682A2A820461CB035876 /* WCTPropertyBase.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTPropertyBase.mm; path = objc/WCDB/interface/orm/coding/WCTPropertyBase.mm; sourceTree = "<group>"; };
+		3EC658789D70ADEB42135D2DF4F18A4D /* WCTColumnBinding.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTColumnBinding.mm; path = objc/WCDB/interface/orm/binding/WCTColumnBinding.mm; sourceTree = "<group>"; };
 		3ED5E2A23CE8B4095FC0C67DF44745C8 /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIProgressView+AFNetworking.m"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
 		3EF2043C81F3D0D492154251F35E7A7A /* statement_select.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_select.cpp; path = objc/WCDB/abstract/statement_select.cpp; sourceTree = "<group>"; };
 		3F18101FF24D77C043A8E78E670941BE /* SDWeakProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDWeakProxy.m; path = SDWebImage/Private/SDWeakProxy.m; sourceTree = "<group>"; };
 		3F18DB49052548EC686B98D7B0BA58D1 /* Reachability.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Reachability.debug.xcconfig; sourceTree = "<group>"; };
-		3F3900FE1D06BD6AAC52378295D418F8 /* pragma.c */ = {isa = PBXFileReference; includeInIndex = 1; name = pragma.c; path = src/pragma.c; sourceTree = "<group>"; };
-		3F4633B2A13C43D1604E4C8EBE11E988 /* WCTInterface+Table.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTInterface+Table.mm"; path = "objc/WCDB/interface/table/WCTInterface+Table.mm"; sourceTree = "<group>"; };
+		3F3900FE1D06BD6AAC52378295D418F8 /* pragma.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pragma.c; path = src/pragma.c; sourceTree = "<group>"; };
+		3F4633B2A13C43D1604E4C8EBE11E988 /* WCTInterface+Table.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTInterface+Table.mm"; path = "objc/WCDB/interface/table/WCTInterface+Table.mm"; sourceTree = "<group>"; };
 		3F4A9FD20749D5A229FBF7E60625EE4C /* LOTStrokeRenderer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTStrokeRenderer.h; path = "lottie-ios/Classes/RenderSystem/RenderNodes/LOTStrokeRenderer.h"; sourceTree = "<group>"; };
 		3F8FBB74C9D450403A897411BD243243 /* keywordhash.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = keywordhash.h; sourceTree = "<group>"; };
 		3FBA116844C9E18DD1288667489420EE /* GCDWebServer-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "GCDWebServer-prefix.pch"; sourceTree = "<group>"; };
 		3FD6C215E90F7CCD1819844FB3F20221 /* LOTBlockCallback.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTBlockCallback.m; path = "lottie-ios/Classes/Private/LOTBlockCallback.m"; sourceTree = "<group>"; };
 		3FE54960F2BEB872CF814B130AC16DD9 /* YCEasyTool.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = YCEasyTool.release.xcconfig; sourceTree = "<group>"; };
-		3FFC01680410622811D5E0303C0BE90C /* util.c */ = {isa = PBXFileReference; includeInIndex = 1; name = util.c; path = src/util.c; sourceTree = "<group>"; };
-		400FF55D0451E7A8F33A3D0D3E11C1B9 /* Reachability */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = Reachability; path = libReachability.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3FFC01680410622811D5E0303C0BE90C /* util.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = util.c; path = src/util.c; sourceTree = "<group>"; };
+		400FF55D0451E7A8F33A3D0D3E11C1B9 /* libReachability.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReachability.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		401F4D91959AFBB7FD5A060AF9D28C88 /* SRWebSocket.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SRWebSocket.m; path = SocketRocket/SRWebSocket.m; sourceTree = "<group>"; };
 		4027CC4353651BDD99F7C3D5E1314AED /* ISO8601Serialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ISO8601Serialization.m; path = Sources/ISO8601Serialization.m; sourceTree = "<group>"; };
 		40E847759968134272E8AD9AA7131891 /* os_wcdb.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = os_wcdb.h; path = src/os_wcdb.h; sourceTree = "<group>"; };
 		40EDEB04BC9D74B6B6A712C1E19CE811 /* core_base.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = core_base.hpp; path = objc/WCDB/core/core_base.hpp; sourceTree = "<group>"; };
 		40F209B46C5516106D031D9619E013DE /* WCTStatistics+Compatible.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTStatistics+Compatible.h"; path = "objc/WCDB/interface/compatible/WCTStatistics+Compatible.h"; sourceTree = "<group>"; };
-		410712477F723A436BCCC7C8FEB5CEF8 /* legacy.c */ = {isa = PBXFileReference; includeInIndex = 1; name = legacy.c; path = src/legacy.c; sourceTree = "<group>"; };
+		410712477F723A436BCCC7C8FEB5CEF8 /* legacy.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = legacy.c; path = src/legacy.c; sourceTree = "<group>"; };
 		4150DC65A0E40978059D16AE63AA4BC2 /* Pods-EulixSpace-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-EulixSpace-frameworks.sh"; sourceTree = "<group>"; };
 		41A8446A0421EA93CD8E38D679716C36 /* WCTPropertyMacro.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTPropertyMacro.h; path = objc/WCDB/interface/orm/macro/WCTPropertyMacro.h; sourceTree = "<group>"; };
 		41AE451F8F413E578DB3CD28BF4F0742 /* SDDeviceHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDDeviceHelper.m; path = SDWebImage/Private/SDDeviceHelper.m; sourceTree = "<group>"; };
@@ -1784,7 +1785,7 @@
 		44FCDBA03CFA083CC9AE35D8C28D4472 /* YCForeverSqlHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = YCForeverSqlHelper.m; path = YCEasyTool/Classes/Forever/YCForeverSqlHelper.m; sourceTree = "<group>"; };
 		45070F16BC844630B03821E786FF6828 /* WCTDatabase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTDatabase.h; path = objc/WCDB/interface/declare/WCTDatabase.h; sourceTree = "<group>"; };
 		45086483C137B0BEC2B407882D21459E /* WCTDelete.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTDelete.h; path = objc/WCDB/interface/chaincall/WCTDelete.h; sourceTree = "<group>"; };
-		4532378DDB8C8F60F182C54E86E337C6 /* WCTStatement+Compatible.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTStatement+Compatible.mm"; path = "objc/WCDB/interface/compatible/WCTStatement+Compatible.mm"; sourceTree = "<group>"; };
+		4532378DDB8C8F60F182C54E86E337C6 /* WCTStatement+Compatible.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTStatement+Compatible.mm"; path = "objc/WCDB/interface/compatible/WCTStatement+Compatible.mm"; sourceTree = "<group>"; };
 		453F96F045162D7E59E7AB515A5D4B41 /* SQLiteRepairKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SQLiteRepairKit.release.xcconfig; sourceTree = "<group>"; };
 		4599A717728B7F1DE10E4E40201FF242 /* WCTCompatible.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTCompatible.h; path = objc/WCDB/interface/compatible/WCTCompatible.h; sourceTree = "<group>"; };
 		45A48FEBB8058462EE5F188131FACCE2 /* SDWebImageError.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDWebImageError.m; path = SDWebImage/Core/SDWebImageError.m; sourceTree = "<group>"; };
@@ -1803,7 +1804,7 @@
 		4828C77BF8E445C70ED471FC99C7AA8A /* SVProgressHUD.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SVProgressHUD.release.xcconfig; sourceTree = "<group>"; };
 		485306DD1C44FC319A3B0F008562CC31 /* YCBase-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "YCBase-dummy.m"; sourceTree = "<group>"; };
 		4862E8652CFBCAF3E93014B23936132B /* LOTShapeFill.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTShapeFill.m; path = "lottie-ios/Classes/Models/LOTShapeFill.m"; sourceTree = "<group>"; };
-		48ACF38225AF5129416A1F090F6D3286 /* YYCache */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = YYCache; path = libYYCache.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		48ACF38225AF5129416A1F090F6D3286 /* libYYCache.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libYYCache.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		48FBB61468CB49069BC4D724DC326FF5 /* WCTTable+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTTable+Private.h"; path = "objc/WCDB/interface/table/WCTTable+Private.h"; sourceTree = "<group>"; };
 		495A882D23DBFB2B6E1AF87B8C7625A9 /* GCDWebServer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = GCDWebServer.m; path = GCDWebServer/Core/GCDWebServer.m; sourceTree = "<group>"; };
 		4962CF2D3F233037854F3EF7800CF48B /* JSONModelClassProperty.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = JSONModelClassProperty.h; path = JSONModel/JSONModel/JSONModelClassProperty.h; sourceTree = "<group>"; };
@@ -1821,8 +1822,8 @@
 		4B633BC81FFF8AF9483F07A7F248706E /* NSURLRequest+SRWebSocket.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSURLRequest+SRWebSocket.m"; path = "SocketRocket/NSURLRequest+SRWebSocket.m"; sourceTree = "<group>"; };
 		4B673FD49DE80DDA8E8513F646DDA21B /* MASViewAttribute.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MASViewAttribute.h; path = Masonry/MASViewAttribute.h; sourceTree = "<group>"; };
 		4B77B25DB0078EEA1803EC695099D2CF /* SQLiteRepairKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SQLiteRepairKit-dummy.m"; sourceTree = "<group>"; };
-		4BB074C186780A3D725F9E16C6C57279 /* dbstat.c */ = {isa = PBXFileReference; includeInIndex = 1; name = dbstat.c; path = src/dbstat.c; sourceTree = "<group>"; };
-		4BE9C250EFDCE8DD77012508E5810720 /* resolve.c */ = {isa = PBXFileReference; includeInIndex = 1; name = resolve.c; path = src/resolve.c; sourceTree = "<group>"; };
+		4BB074C186780A3D725F9E16C6C57279 /* dbstat.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = dbstat.c; path = src/dbstat.c; sourceTree = "<group>"; };
+		4BE9C250EFDCE8DD77012508E5810720 /* resolve.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = resolve.c; path = src/resolve.c; sourceTree = "<group>"; };
 		4BEA3CC45D479D3FE258646D7CB3E009 /* MASCompositeConstraint.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MASCompositeConstraint.m; path = Masonry/MASCompositeConstraint.m; sourceTree = "<group>"; };
 		4C1DDF703B03246465D4D52812872155 /* TAAnimatedDotView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = TAAnimatedDotView.m; path = SDCycleScrollView/Lib/SDCycleScrollView/PageControl/TAAnimatedDotView.m; sourceTree = "<group>"; };
 		4C3201E25F98D8904AB0AB0C0467F8FA /* SDWebImageDefine.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDWebImageDefine.h; path = SDWebImage/Core/SDWebImageDefine.h; sourceTree = "<group>"; };
@@ -1840,10 +1841,10 @@
 		4F2E692FC70CDE93BF9BD85159F94609 /* SDDisplayLink.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDDisplayLink.h; path = SDWebImage/Private/SDDisplayLink.h; sourceTree = "<group>"; };
 		4F51F1FD05B42B95CD35D62FB1958422 /* SDWebImageDownloaderResponseModifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDWebImageDownloaderResponseModifier.m; path = SDWebImage/Core/SDWebImageDownloaderResponseModifier.m; sourceTree = "<group>"; };
 		4F5B829FF474B3D9F0F37D818B6CC259 /* LOTFillRenderer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTFillRenderer.m; path = "lottie-ios/Classes/RenderSystem/RenderNodes/LOTFillRenderer.m"; sourceTree = "<group>"; };
-		4F80E63B3378DD8F6B4FCE535603CCC7 /* WCTCompatible.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTCompatible.mm; path = objc/WCDB/interface/compatible/WCTCompatible.mm; sourceTree = "<group>"; };
+		4F80E63B3378DD8F6B4FCE535603CCC7 /* WCTCompatible.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTCompatible.mm; path = objc/WCDB/interface/compatible/WCTCompatible.mm; sourceTree = "<group>"; };
 		4F86A6790262A4E70F58C6E5F95654EC /* View+MASShorthandAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "View+MASShorthandAdditions.h"; path = "Masonry/View+MASShorthandAdditions.h"; sourceTree = "<group>"; };
-		4FA4CF2759FC49DD15DA983B5D6786F3 /* pcache.c */ = {isa = PBXFileReference; includeInIndex = 1; name = pcache.c; path = src/pcache.c; sourceTree = "<group>"; };
-		50457429EE9F0A899814F11C27108195 /* parse.c */ = {isa = PBXFileReference; includeInIndex = 1; path = parse.c; sourceTree = "<group>"; };
+		4FA4CF2759FC49DD15DA983B5D6786F3 /* pcache.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pcache.c; path = src/pcache.c; sourceTree = "<group>"; };
+		50457429EE9F0A899814F11C27108195 /* parse.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; path = parse.c; sourceTree = "<group>"; };
 		5094D7D01760E8FA420579487418082D /* LOTShapeGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTShapeGroup.h; path = "lottie-ios/Classes/Models/LOTShapeGroup.h"; sourceTree = "<group>"; };
 		5097910FFFC426F2B018704147C829B2 /* WCTDeclare.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTDeclare.h; path = objc/WCDB/interface/declare/WCTDeclare.h; sourceTree = "<group>"; };
 		50B46AB6CE73DAC5CF174A5DE38FAEEF /* GKPanGestureRecognizer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = GKPanGestureRecognizer.m; path = GKPhotoBrowser/Core/GKPanGestureRecognizer.m; sourceTree = "<group>"; };
@@ -1855,29 +1856,29 @@
 		513E17FF6548DA2BD549636FA5F5C3C1 /* LOTCircleAnimator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTCircleAnimator.m; path = "lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTCircleAnimator.m"; sourceTree = "<group>"; };
 		51419F75523DD3B77B448937CE8F5ADC /* LOTAssetGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTAssetGroup.h; path = "lottie-ios/Classes/Models/LOTAssetGroup.h"; sourceTree = "<group>"; };
 		51BA6A79015A39251EADF7A57173E40E /* MASUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MASUtilities.h; path = Masonry/MASUtilities.h; sourceTree = "<group>"; };
-		51BA97E8B5085EFFB47BC9C0B785CEA7 /* lottie-ios */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "lottie-ios"; path = "liblottie-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		51BA97E8B5085EFFB47BC9C0B785CEA7 /* liblottie-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "liblottie-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5204D43B88BF7ED3EC51C03D02960862 /* DDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDDispatchQueueLogFormatter.m; path = Sources/CocoaLumberjack/Extensions/DDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
-		5219A3AE4C1AD6448E6B58935CB8B58F /* update.c */ = {isa = PBXFileReference; includeInIndex = 1; name = update.c; path = src/update.c; sourceTree = "<group>"; };
+		5219A3AE4C1AD6448E6B58935CB8B58F /* update.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = update.c; path = src/update.c; sourceTree = "<group>"; };
 		522A5C99B30C0709460AEE88ACA86B74 /* SSZipArchive.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SSZipArchive.debug.xcconfig; sourceTree = "<group>"; };
 		52369FC6FE85FB585837D0D093A7596F /* SDImageCodersManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDImageCodersManager.m; path = SDWebImage/Core/SDImageCodersManager.m; sourceTree = "<group>"; };
 		526E1FB570B28FEEE20D8EE85EAEA95F /* statement_insert.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = statement_insert.hpp; path = objc/WCDB/abstract/statement_insert.hpp; sourceTree = "<group>"; };
 		52CDB0CF8C4DDD572A136F1D644E2E47 /* IQKeyboardManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IQKeyboardManager.h; path = IQKeyboardManager/IQKeyboardManager.h; sourceTree = "<group>"; };
-		531A3BA0FBD99F01A21FDD853850FC99 /* vtab.c */ = {isa = PBXFileReference; includeInIndex = 1; name = vtab.c; path = src/vtab.c; sourceTree = "<group>"; };
+		531A3BA0FBD99F01A21FDD853850FC99 /* vtab.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = vtab.c; path = src/vtab.c; sourceTree = "<group>"; };
 		53B805A61A44E9B14F00A04C0DE36A5E /* JSONModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = JSONModel.h; path = JSONModel/JSONModel/JSONModel.h; sourceTree = "<group>"; };
 		540A0C266E1AD026D552D8CA4269D684 /* SDWebImageCacheKeyFilter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDWebImageCacheKeyFilter.m; path = SDWebImage/Core/SDWebImageCacheKeyFilter.m; sourceTree = "<group>"; };
 		544E52FD92F3003A592F00F59D40EF40 /* MJExtension-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MJExtension-prefix.pch"; sourceTree = "<group>"; };
 		5482C23D48A2677D917939249486BC3F /* IQKeyboardReturnKeyHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IQKeyboardReturnKeyHandler.m; path = IQKeyboardManager/IQKeyboardReturnKeyHandler.m; sourceTree = "<group>"; };
-		54C661AF44397F4D17B0D53F5214E910 /* build.c */ = {isa = PBXFileReference; includeInIndex = 1; name = build.c; path = src/build.c; sourceTree = "<group>"; };
+		54C661AF44397F4D17B0D53F5214E910 /* build.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = build.c; path = src/build.c; sourceTree = "<group>"; };
 		54DB47EDD40315053ECE9383EFC29CC8 /* IQNSArray+Sort.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "IQNSArray+Sort.m"; path = "IQKeyboardManager/Categories/IQNSArray+Sort.m"; sourceTree = "<group>"; };
 		55328737980083091688CAC66F20C084 /* statement_pragma.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_pragma.cpp; path = objc/WCDB/abstract/statement_pragma.cpp; sourceTree = "<group>"; };
-		5579D4DB329C6B6A6D2F9B8E72BE933B /* mem1.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mem1.c; path = src/mem1.c; sourceTree = "<group>"; };
+		5579D4DB329C6B6A6D2F9B8E72BE933B /* mem1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mem1.c; path = src/mem1.c; sourceTree = "<group>"; };
 		55D9A3A0C6670BB4438A3A273F6E34BB /* WCDBOptimizedSQLCipher.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = WCDBOptimizedSQLCipher.debug.xcconfig; sourceTree = "<group>"; };
 		55F9EEF718CF9A0C0D85C356EC52A600 /* MASConstraint.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MASConstraint.h; path = Masonry/MASConstraint.h; sourceTree = "<group>"; };
 		5654240657692EB805C2E792E3A9E0FB /* LOTShapeTransform.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTShapeTransform.h; path = "lottie-ios/Classes/Models/LOTShapeTransform.h"; sourceTree = "<group>"; };
-		56B97426CD50C41F021445ADCBAD26C0 /* icu.c */ = {isa = PBXFileReference; includeInIndex = 1; name = icu.c; path = ext/icu/icu.c; sourceTree = "<group>"; };
-		56D97D0D374E98A26ABB3B3E93F59576 /* mz_compat.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mz_compat.c; path = SSZipArchive/minizip/mz_compat.c; sourceTree = "<group>"; };
+		56B97426CD50C41F021445ADCBAD26C0 /* icu.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = icu.c; path = ext/icu/icu.c; sourceTree = "<group>"; };
+		56D97D0D374E98A26ABB3B3E93F59576 /* mz_compat.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mz_compat.c; path = SSZipArchive/minizip/mz_compat.c; sourceTree = "<group>"; };
 		56ED5A0BAF4AD353082910DC29815A4D /* CocoaLumberjack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CocoaLumberjack.h; path = "Sources/CocoaLumberjack/Supporting Files/CocoaLumberjack.h"; sourceTree = "<group>"; };
-		57040424895531705B91D6C2E08AB0BC /* WCTDatabase+Core.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTDatabase+Core.mm"; path = "objc/WCDB/interface/core/WCTDatabase+Core.mm"; sourceTree = "<group>"; };
+		57040424895531705B91D6C2E08AB0BC /* WCTDatabase+Core.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTDatabase+Core.mm"; path = "objc/WCDB/interface/core/WCTDatabase+Core.mm"; sourceTree = "<group>"; };
 		57539A6CCF5F92DA28181BC84C646552 /* NSData+ImageContentType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSData+ImageContentType.h"; path = "SDWebImage/Core/NSData+ImageContentType.h"; sourceTree = "<group>"; };
 		576AE3F7C55A10040D3C7228F4E62AEC /* fts3Int.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = fts3Int.h; path = ext/fts3/fts3Int.h; sourceTree = "<group>"; };
 		57CEE4AB389568FE5279D51CF0C29E4A /* mz_strm.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mz_strm.h; path = SSZipArchive/minizip/mz_strm.h; sourceTree = "<group>"; };
@@ -1898,7 +1899,7 @@
 		5C27A160D01F49DA3D778FD7E7EE5A29 /* mutex_wcdb.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mutex_wcdb.h; path = src/mutex_wcdb.h; sourceTree = "<group>"; };
 		5D29E8B1CCB34EDBF12B7E81342EC463 /* WCTSequence+WCTTableCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTSequence+WCTTableCoding.h"; path = "objc/WCDB/interface/builtin/WCTSequence+WCTTableCoding.h"; sourceTree = "<group>"; };
 		5D59A99232B77BAED89E1675FBCC9C16 /* GCDWebServerStreamedResponse.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = GCDWebServerStreamedResponse.m; path = GCDWebServer/Responses/GCDWebServerStreamedResponse.m; sourceTree = "<group>"; };
-		5DCCF5B5F792D4EC76585F50AC7D8D7B /* SQLiteRepairKit */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = SQLiteRepairKit; path = libSQLiteRepairKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		5DCCF5B5F792D4EC76585F50AC7D8D7B /* libSQLiteRepairKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSQLiteRepairKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		5DDD5E897A7B9CF34DEFA68C1B17441E /* order_term.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = order_term.cpp; path = objc/WCDB/abstract/order_term.cpp; sourceTree = "<group>"; };
 		5E105BD0629C03C485A6FA6D401C84CD /* LOTShapeTrimPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTShapeTrimPath.h; path = "lottie-ios/Classes/Models/LOTShapeTrimPath.h"; sourceTree = "<group>"; };
 		5E37955BCAFF624C96A5748C20ED2542 /* statement_release.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_release.cpp; path = objc/WCDB/abstract/statement_release.cpp; sourceTree = "<group>"; };
@@ -1910,14 +1911,14 @@
 		5FCBDD60CACC8C2A888D5961396451E7 /* NSDate+ISO8601.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSDate+ISO8601.h"; path = "Sources/NSDate+ISO8601.h"; sourceTree = "<group>"; };
 		60181EC6A5E15C65B9EE9EAF9C0CE5D2 /* statement_release.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = statement_release.hpp; path = objc/WCDB/abstract/statement_release.hpp; sourceTree = "<group>"; };
 		606210E69B877DEBC6D4E05B61EE42E5 /* AFNetworking-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AFNetworking-prefix.pch"; sourceTree = "<group>"; };
-		60642EEA7CFB25103DD17C65D8D226B3 /* WCTResult.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTResult.mm; path = objc/WCDB/interface/orm/coding/WCTResult.mm; sourceTree = "<group>"; };
+		60642EEA7CFB25103DD17C65D8D226B3 /* WCTResult.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTResult.mm; path = objc/WCDB/interface/orm/coding/WCTResult.mm; sourceTree = "<group>"; };
 		6099A1C99B0C4293095C125FEA1556E3 /* IQUIScrollView+Additions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "IQUIScrollView+Additions.h"; path = "IQKeyboardManager/Categories/IQUIScrollView+Additions.h"; sourceTree = "<group>"; };
 		60AAB2F6AC9B37D8FF1836141CC9A35B /* DDLogMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDLogMacros.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDLogMacros.h; sourceTree = "<group>"; };
 		60DBDE38A8A81E01B66325033DF2F288 /* LOTAnimationView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTAnimationView.m; path = "lottie-ios/Classes/Private/LOTAnimationView.m"; sourceTree = "<group>"; };
 		60FC7055139A34E79445AB58150D2E42 /* YCTabBarController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCTabBarController.h; path = YCEasyTool/Classes/UI/TabBarController/YCTabBarController.h; sourceTree = "<group>"; };
 		6114DF4D0055839D86D76279AB3FF853 /* SVIndefiniteAnimatedView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SVIndefiniteAnimatedView.h; path = SVProgressHUD/SVIndefiniteAnimatedView.h; sourceTree = "<group>"; };
-		612028EAFF1C2054A0EB821A9C9F2440 /* SAMKeychain */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = SAMKeychain; path = libSAMKeychain.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		616BE742C25076A091F8B1A052829049 /* WCTTable+Convenient.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTTable+Convenient.mm"; path = "objc/WCDB/interface/convenient/WCTTable+Convenient.mm"; sourceTree = "<group>"; };
+		612028EAFF1C2054A0EB821A9C9F2440 /* libSAMKeychain.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSAMKeychain.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		616BE742C25076A091F8B1A052829049 /* WCTTable+Convenient.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTTable+Convenient.mm"; path = "objc/WCDB/interface/convenient/WCTTable+Convenient.mm"; sourceTree = "<group>"; };
 		61AB5B80B0BEF83D105C4ED7A1736864 /* SRRandom.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SRRandom.h; path = SocketRocket/Internal/Utilities/SRRandom.h; sourceTree = "<group>"; };
 		624869DFD72DB632DCCED208E2C543C0 /* SDImageCacheDefine.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDImageCacheDefine.m; path = SDWebImage/Core/SDImageCacheDefine.m; sourceTree = "<group>"; };
 		62496F884C56D855B7349ECFAFA3D1A1 /* SQLiteRepairKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SQLiteRepairKit-prefix.pch"; sourceTree = "<group>"; };
@@ -1925,16 +1926,16 @@
 		6281F009FE8C8018910B48A8B7682335 /* AFHTTPSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPSessionManager.h; path = AFNetworking/AFHTTPSessionManager.h; sourceTree = "<group>"; };
 		62C04213F09D0489B8459DB082BE6E59 /* LOTValueInterpolator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTValueInterpolator.h; path = "lottie-ios/Classes/RenderSystem/InterpolatorNodes/LOTValueInterpolator.h"; sourceTree = "<group>"; };
 		634BE6E43002F0F17B6C8E8CB332FE29 /* FileMD5Hash.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FileMD5Hash.debug.xcconfig; sourceTree = "<group>"; };
-		636630AFF420ACB38770148B7D85B614 /* crypto_libtomcrypt.c */ = {isa = PBXFileReference; includeInIndex = 1; name = crypto_libtomcrypt.c; path = src/crypto_libtomcrypt.c; sourceTree = "<group>"; };
+		636630AFF420ACB38770148B7D85B614 /* crypto_libtomcrypt.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = crypto_libtomcrypt.c; path = src/crypto_libtomcrypt.c; sourceTree = "<group>"; };
 		63B7A6434170D2E8A737629D061A635A /* MASConstraintMaker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MASConstraintMaker.h; path = Masonry/MASConstraintMaker.h; sourceTree = "<group>"; };
 		63D8ED5B3A0E4D535AF820513DEC386C /* SRProxyConnect.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SRProxyConnect.h; path = SocketRocket/Internal/Proxy/SRProxyConnect.h; sourceTree = "<group>"; };
-		63E4285601CA23211E7337D84470313D /* attach.c */ = {isa = PBXFileReference; includeInIndex = 1; name = attach.c; path = src/attach.c; sourceTree = "<group>"; };
+		63E4285601CA23211E7337D84470313D /* attach.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = attach.c; path = src/attach.c; sourceTree = "<group>"; };
 		64322F03F985D5FBE491E0F70794963D /* DDLog.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDLog.m; path = Sources/CocoaLumberjack/DDLog.m; sourceTree = "<group>"; };
 		646CD4A50FB4DE2A654E8671DC7B51CC /* LOTAssetGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTAssetGroup.m; path = "lottie-ios/Classes/Models/LOTAssetGroup.m"; sourceTree = "<group>"; };
 		64C93C54630D1DA752C411B760FEDDE4 /* SSZipArchive.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SSZipArchive.release.xcconfig; sourceTree = "<group>"; };
 		64DA98949DA4C05A42017D0ED617E042 /* mz_strm_pkcrypt.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mz_strm_pkcrypt.h; path = SSZipArchive/minizip/mz_strm_pkcrypt.h; sourceTree = "<group>"; };
 		652E4C0EC043E3BE58659FD46C2FCE6A /* LOTAnimatorNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTAnimatorNode.m; path = "lottie-ios/Classes/RenderSystem/LOTAnimatorNode.m"; sourceTree = "<group>"; };
-		655803DA852473EE44C58C4F7961C50A /* vdbemem.c */ = {isa = PBXFileReference; includeInIndex = 1; name = vdbemem.c; path = src/vdbemem.c; sourceTree = "<group>"; };
+		655803DA852473EE44C58C4F7961C50A /* vdbemem.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = vdbemem.c; path = src/vdbemem.c; sourceTree = "<group>"; };
 		65BF5B54C990DE0F6D6599FCED96A987 /* YCBase.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = YCBase.release.xcconfig; sourceTree = "<group>"; };
 		660F527EADD2FEAF0198E63F43EDF571 /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
 		662DA202F6F58CED079F7FF7AE6AA64C /* GCDWebServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GCDWebServer.h; path = GCDWebServer/Core/GCDWebServer.h; sourceTree = "<group>"; };
@@ -1959,42 +1960,42 @@
 		6A270BD08EFF7B36C56359DF0CE0F5FE /* mz_strm_mem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mz_strm_mem.h; path = SSZipArchive/minizip/mz_strm_mem.h; sourceTree = "<group>"; };
 		6A3C7926C4970EED7C6E3726FDAF2D50 /* SDImageCoder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDImageCoder.h; path = SDWebImage/Core/SDImageCoder.h; sourceTree = "<group>"; };
 		6A3CE87E34D3705C70339B6CE4E80189 /* FileMD5Hash-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FileMD5Hash-prefix.pch"; sourceTree = "<group>"; };
-		6A478A3057FEF28D1E5226819D68D676 /* sqliterk_btree.c */ = {isa = PBXFileReference; includeInIndex = 1; name = sqliterk_btree.c; path = repair/sqliterk_btree.c; sourceTree = "<group>"; };
+		6A478A3057FEF28D1E5226819D68D676 /* sqliterk_btree.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = sqliterk_btree.c; path = repair/sqliterk_btree.c; sourceTree = "<group>"; };
 		6A4CD5A54224FA75F2044DF0F73B109C /* WCTRowSelect+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTRowSelect+Private.h"; path = "objc/WCDB/interface/chaincall/WCTRowSelect+Private.h"; sourceTree = "<group>"; };
 		6A6A2E502C039942D1EBB128F010064C /* SDImageIOCoder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDImageIOCoder.m; path = SDWebImage/Core/SDImageIOCoder.m; sourceTree = "<group>"; };
 		6A9EE9CAEB992A5D64AA26234F23AC20 /* NSRunLoop+SRWebSocket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSRunLoop+SRWebSocket.h"; path = "SocketRocket/NSRunLoop+SRWebSocket.h"; sourceTree = "<group>"; };
-		6AAD99F5726BD47F1238715E8267BE71 /* WCTTable+ChainCall.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTTable+ChainCall.mm"; path = "objc/WCDB/interface/chaincall/WCTTable+ChainCall.mm"; sourceTree = "<group>"; };
-		6BC328B30D8D42004F5660C80DC3C262 /* WCTRowSelect.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTRowSelect.mm; path = objc/WCDB/interface/chaincall/WCTRowSelect.mm; sourceTree = "<group>"; };
+		6AAD99F5726BD47F1238715E8267BE71 /* WCTTable+ChainCall.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTTable+ChainCall.mm"; path = "objc/WCDB/interface/chaincall/WCTTable+ChainCall.mm"; sourceTree = "<group>"; };
+		6BC328B30D8D42004F5660C80DC3C262 /* WCTRowSelect.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTRowSelect.mm; path = objc/WCDB/interface/chaincall/WCTRowSelect.mm; sourceTree = "<group>"; };
 		6BF0B53D9BBCF025BD8693A595A104FD /* FileHash.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FileHash.h; path = Library/FileHash.h; sourceTree = "<group>"; };
-		6C35F87F2C55D0EF0D3929FF165A328F /* malloc.c */ = {isa = PBXFileReference; includeInIndex = 1; name = malloc.c; path = src/malloc.c; sourceTree = "<group>"; };
+		6C35F87F2C55D0EF0D3929FF165A328F /* malloc.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = malloc.c; path = src/malloc.c; sourceTree = "<group>"; };
 		6C5843F7376614FA27E841F641F82F3F /* SocketRocket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SocketRocket.h; path = SocketRocket/SocketRocket.h; sourceTree = "<group>"; };
-		6C69CA351D17C4E09AD21E9F8C3EE6C9 /* WCTDatabase+File.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTDatabase+File.mm"; path = "objc/WCDB/interface/database/WCTDatabase+File.mm"; sourceTree = "<group>"; };
+		6C69CA351D17C4E09AD21E9F8C3EE6C9 /* WCTDatabase+File.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTDatabase+File.mm"; path = "objc/WCDB/interface/database/WCTDatabase+File.mm"; sourceTree = "<group>"; };
 		6CA690794FBA3B42DA820A7E28D8999A /* WCTTokenizer+Apple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTTokenizer+Apple.h"; path = "objc/WCDB/interface/fts/WCTTokenizer+Apple.h"; sourceTree = "<group>"; };
 		6CD9F7B614C7FEF3489D2CCDC08E615E /* SDAssociatedObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDAssociatedObject.h; path = SDWebImage/Private/SDAssociatedObject.h; sourceTree = "<group>"; };
 		6CDEE91F710D0DC913AE2F457DE6B1A9 /* LOTShapeGradientFill.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTShapeGradientFill.m; path = "lottie-ios/Classes/Models/LOTShapeGradientFill.m"; sourceTree = "<group>"; };
-		6CEFE1C74A0A791CB6E2A2DF934FB14F /* mutex_wcdb.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mutex_wcdb.c; path = src/mutex_wcdb.c; sourceTree = "<group>"; };
+		6CEFE1C74A0A791CB6E2A2DF934FB14F /* mutex_wcdb.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mutex_wcdb.c; path = src/mutex_wcdb.c; sourceTree = "<group>"; };
 		6DE9A3CB4E536D3B89D4BD687B3EBFB1 /* DDFileLogger+Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "DDFileLogger+Internal.h"; path = "Sources/CocoaLumberjack/DDFileLogger+Internal.h"; sourceTree = "<group>"; };
 		6DEEDBC9DF96B310246F4BA87CD0CE79 /* SDAsyncBlockOperation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDAsyncBlockOperation.h; path = SDWebImage/Private/SDAsyncBlockOperation.h; sourceTree = "<group>"; };
 		6DF9965CBD78475D45DF75D056EC867A /* LOTAnimatedControl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTAnimatedControl.h; path = "lottie-ios/Classes/PublicHeaders/LOTAnimatedControl.h"; sourceTree = "<group>"; };
 		6E7B9E4C00C9C931F4F137759D2A9FBD /* UIColor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = UIColor.m; path = "lottie-ios/Classes/MacCompatibility/UIColor.m"; sourceTree = "<group>"; };
-		6E7C7C50EFF9F784A2691DA53392F22E /* queue.c */ = {isa = PBXFileReference; includeInIndex = 1; name = queue.c; path = src/queue.c; sourceTree = "<group>"; };
+		6E7C7C50EFF9F784A2691DA53392F22E /* queue.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = queue.c; path = src/queue.c; sourceTree = "<group>"; };
 		6EB0008086F654E5533AA93F38CD43BE /* IQTitleBarButtonItem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IQTitleBarButtonItem.h; path = IQKeyboardManager/IQToolbar/IQTitleBarButtonItem.h; sourceTree = "<group>"; };
 		6EC89F5AD8C7A05F304B68347D3CB637 /* LOTShapeCircle.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTShapeCircle.m; path = "lottie-ios/Classes/Models/LOTShapeCircle.m"; sourceTree = "<group>"; };
 		6F104336CB6F0A0045AADBD94687E9DC /* YCForeverSqlHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCForeverSqlHelper.h; path = YCEasyTool/Classes/Forever/YCForeverSqlHelper.h; sourceTree = "<group>"; };
 		6F936B429A4AE1EB21CCF396E88632A9 /* YCPopMenu.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCPopMenu.h; path = YCEasyTool/Classes/UI/PopMenu/YCPopMenu.h; sourceTree = "<group>"; };
 		70189F35F71623FFF1D64019DB861EFD /* handle_recyclable.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = handle_recyclable.cpp; path = objc/WCDB/core/handle_recyclable.cpp; sourceTree = "<group>"; };
 		703AF860A6E4C29507715DEA5EF2A837 /* NSObject+YYModel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+YYModel.m"; path = "YYModel/NSObject+YYModel.m"; sourceTree = "<group>"; };
-		708163C39614F4158EE10A8F35D1032E /* backup.c */ = {isa = PBXFileReference; includeInIndex = 1; name = backup.c; path = src/backup.c; sourceTree = "<group>"; };
+		708163C39614F4158EE10A8F35D1032E /* backup.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = backup.c; path = src/backup.c; sourceTree = "<group>"; };
 		70A1E9FC34C6F15A829F051BF5B64510 /* MJProperty.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MJProperty.h; path = MJExtension/MJProperty.h; sourceTree = "<group>"; };
 		715EFFB74DD11AC7410C7B028AF68565 /* SRDelegateController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SRDelegateController.h; path = SocketRocket/Internal/Delegate/SRDelegateController.h; sourceTree = "<group>"; };
-		723A167F2F5EFA034D31E02454AB1C30 /* ctime.c */ = {isa = PBXFileReference; includeInIndex = 1; name = ctime.c; path = src/ctime.c; sourceTree = "<group>"; };
+		723A167F2F5EFA034D31E02454AB1C30 /* ctime.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = ctime.c; path = src/ctime.c; sourceTree = "<group>"; };
 		723A7A49A136392E89F312B14E20DEEE /* NSURLRequest+SRWebSocketPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLRequest+SRWebSocketPrivate.h"; path = "SocketRocket/Internal/NSURLRequest+SRWebSocketPrivate.h"; sourceTree = "<group>"; };
 		72516328689052893961B4745E62B179 /* transaction.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = transaction.hpp; path = objc/WCDB/core/transaction.hpp; sourceTree = "<group>"; };
 		7261136B6509C65E1D7CF6FE97E47A5E /* AFNetworkReachabilityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkReachabilityManager.m; path = AFNetworking/AFNetworkReachabilityManager.m; sourceTree = "<group>"; };
 		727B92F37DE0B5A32ED3A2EFA70DC343 /* SAMKeychainQuery.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SAMKeychainQuery.m; path = Sources/SAMKeychainQuery.m; sourceTree = "<group>"; };
 		72897A60CEB7E38E2992A377C4C2184E /* statement.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = statement.hpp; path = objc/WCDB/abstract/statement.hpp; sourceTree = "<group>"; };
 		72B4BA47626D3EF0D9F829AE5B586DE2 /* LOTRoundedRectAnimator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTRoundedRectAnimator.m; path = "lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTRoundedRectAnimator.m"; sourceTree = "<group>"; };
-		72D61C96432482A30AEA95C21413E4D9 /* mutex_unix.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mutex_unix.c; path = src/mutex_unix.c; sourceTree = "<group>"; };
+		72D61C96432482A30AEA95C21413E4D9 /* mutex_unix.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mutex_unix.c; path = src/mutex_unix.c; sourceTree = "<group>"; };
 		72E8D333870C345688452312EEB995C7 /* IQToolbar.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IQToolbar.m; path = IQKeyboardManager/IQToolbar/IQToolbar.m; sourceTree = "<group>"; };
 		730F022D5251946A4A0B63A1E17B55A7 /* YCTabBarItem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCTabBarItem.h; path = YCEasyTool/Classes/UI/TabBarController/YCTabBarItem.h; sourceTree = "<group>"; };
 		731BBEE220E7C74452251984172DCEAE /* timed_queue.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = timed_queue.hpp; path = objc/WCDB/util/timed_queue.hpp; sourceTree = "<group>"; };
@@ -2015,21 +2016,21 @@
 		7560B88E8180B2993F6ADDFBF297668C /* statement_rollback.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_rollback.cpp; path = objc/WCDB/abstract/statement_rollback.cpp; sourceTree = "<group>"; };
 		759C26438A667B143144A0CE482A12D4 /* LOTSizeInterpolator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTSizeInterpolator.m; path = "lottie-ios/Classes/RenderSystem/InterpolatorNodes/LOTSizeInterpolator.m"; sourceTree = "<group>"; };
 		75DC20F4DD17F4682B67BF1DF342CB9B /* GCDWebServerResponse.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = GCDWebServerResponse.m; path = GCDWebServer/Core/GCDWebServerResponse.m; sourceTree = "<group>"; };
-		762F1632DB0C203BBDBC1DBDB7D7DC50 /* pager.c */ = {isa = PBXFileReference; includeInIndex = 1; name = pager.c; path = src/pager.c; sourceTree = "<group>"; };
+		762F1632DB0C203BBDBC1DBDB7D7DC50 /* pager.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pager.c; path = src/pager.c; sourceTree = "<group>"; };
 		7647434C2C1E393ED17B820AF0873948 /* WCTInsert+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTInsert+Private.h"; path = "objc/WCDB/interface/chaincall/WCTInsert+Private.h"; sourceTree = "<group>"; };
 		767167C6ADBFC28CBA95A87F712478E9 /* WCTDatabase+Core.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTDatabase+Core.h"; path = "objc/WCDB/interface/core/WCTDatabase+Core.h"; sourceTree = "<group>"; };
 		767F513C72313DA42E3B0E3B50CDBE45 /* WCTPropertyBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTPropertyBase.h; path = objc/WCDB/interface/orm/coding/WCTPropertyBase.h; sourceTree = "<group>"; };
 		77434339585F66CB94F9867C1D3D9380 /* SDCycleScrollView-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SDCycleScrollView-dummy.m"; sourceTree = "<group>"; };
 		7747FB0388EAD50AE5065AB048EA4F76 /* JSONModelError.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = JSONModelError.h; path = JSONModel/JSONModel/JSONModelError.h; sourceTree = "<group>"; };
-		77811DE4B9C289A52B6A01E1E0102970 /* WCTIndexBInding.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTIndexBInding.mm; path = objc/WCDB/interface/orm/binding/WCTIndexBInding.mm; sourceTree = "<group>"; };
+		77811DE4B9C289A52B6A01E1E0102970 /* WCTIndexBInding.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTIndexBInding.mm; path = objc/WCDB/interface/orm/binding/WCTIndexBInding.mm; sourceTree = "<group>"; };
 		77885D50BE513CD9E0D153F08D67B3B9 /* SRURLUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SRURLUtilities.m; path = SocketRocket/Internal/Utilities/SRURLUtilities.m; sourceTree = "<group>"; };
 		77A57C554A3D77438C65FE6E3CDD4753 /* SDImageGraphics.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDImageGraphics.m; path = SDWebImage/Core/SDImageGraphics.m; sourceTree = "<group>"; };
 		77CEA8BCBCA40094D809064B235AF894 /* LOTPathInterpolator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTPathInterpolator.m; path = "lottie-ios/Classes/RenderSystem/InterpolatorNodes/LOTPathInterpolator.m"; sourceTree = "<group>"; };
 		77EF8A7E731B6609FA65EBA2D804DD8A /* View+MASAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "View+MASAdditions.h"; path = "Masonry/View+MASAdditions.h"; sourceTree = "<group>"; };
 		785BF3A2ED8740896D6DE3D3FD5BC410 /* LOTPointInterpolator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTPointInterpolator.h; path = "lottie-ios/Classes/RenderSystem/InterpolatorNodes/LOTPointInterpolator.h"; sourceTree = "<group>"; };
 		789C2DC9F2272215F8096956436BC298 /* UIView+SDExtension.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView+SDExtension.m"; path = "SDCycleScrollView/Lib/SDCycleScrollView/UIView+SDExtension.m"; sourceTree = "<group>"; };
-		79132F7FF7F3FDE5275EAD2B8B981966 /* mz_strm_wzaes.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mz_strm_wzaes.c; path = SSZipArchive/minizip/mz_strm_wzaes.c; sourceTree = "<group>"; };
-		795957A079700AD49D887C5615485419 /* delete.c */ = {isa = PBXFileReference; includeInIndex = 1; name = delete.c; path = src/delete.c; sourceTree = "<group>"; };
+		79132F7FF7F3FDE5275EAD2B8B981966 /* mz_strm_wzaes.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mz_strm_wzaes.c; path = SSZipArchive/minizip/mz_strm_wzaes.c; sourceTree = "<group>"; };
+		795957A079700AD49D887C5615485419 /* delete.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = delete.c; path = src/delete.c; sourceTree = "<group>"; };
 		795A90B1228F348423B9954D9BB73DE3 /* YCTableViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCTableViewController.h; path = YCBase/Classes/YCTableViewController.h; sourceTree = "<group>"; };
 		79FB9160BD6C1BE5C9E23CF271BE5A2E /* SDWeakProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDWeakProxy.h; path = SDWebImage/Private/SDWeakProxy.h; sourceTree = "<group>"; };
 		7A6D9D0540866A7374CB0DB905DA5CB4 /* SDWebImageDownloaderDecryptor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDWebImageDownloaderDecryptor.h; path = SDWebImage/Core/SDWebImageDownloaderDecryptor.h; sourceTree = "<group>"; };
@@ -2037,7 +2038,7 @@
 		7B8DE29D56C5649E520B98CEFD893B58 /* AFSecurityPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFSecurityPolicy.h; path = AFNetworking/AFSecurityPolicy.h; sourceTree = "<group>"; };
 		7BBA9279763EB32FE5E3E0F6B1D5ED30 /* statement_delete.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_delete.cpp; path = objc/WCDB/abstract/statement_delete.cpp; sourceTree = "<group>"; };
 		7BF5B2EDA95078F49EB317365F53DCC7 /* SDWebImageOperation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDWebImageOperation.m; path = SDWebImage/Core/SDWebImageOperation.m; sourceTree = "<group>"; };
-		7C03CC174FE39D554F1C54A5B014599F /* fts3_tokenizer1.c */ = {isa = PBXFileReference; includeInIndex = 1; name = fts3_tokenizer1.c; path = ext/fts3/fts3_tokenizer1.c; sourceTree = "<group>"; };
+		7C03CC174FE39D554F1C54A5B014599F /* fts3_tokenizer1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fts3_tokenizer1.c; path = ext/fts3/fts3_tokenizer1.c; sourceTree = "<group>"; };
 		7C2E0055886AF52FF7334E494CA5BE48 /* SRIOConsumerPool.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SRIOConsumerPool.h; path = SocketRocket/Internal/IOConsumer/SRIOConsumerPool.h; sourceTree = "<group>"; };
 		7C4473464AC7205B477130E5643BBA8D /* LOTPolygonAnimator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTPolygonAnimator.m; path = "lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPolygonAnimator.m"; sourceTree = "<group>"; };
 		7C73D93C9140BA35AAFA9CF1F0BFC98E /* UIImage+MultiFormat.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+MultiFormat.m"; path = "SDWebImage/Core/UIImage+MultiFormat.m"; sourceTree = "<group>"; };
@@ -2054,15 +2055,15 @@
 		7E1E6627D924D1C21AE5A9F16429BB18 /* os_common.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = os_common.h; path = src/os_common.h; sourceTree = "<group>"; };
 		7E46DA51826FBCE79A340D1913FA79C0 /* conflict.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = conflict.hpp; path = objc/WCDB/abstract/conflict.hpp; sourceTree = "<group>"; };
 		7E5611DC15722436D17BA806A85013F5 /* NSButton+WebCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSButton+WebCache.m"; path = "SDWebImage/Core/NSButton+WebCache.m"; sourceTree = "<group>"; };
-		7EAF3E589443D5C19E4E64B07384BAB2 /* WCTTransaction+Compatible.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTTransaction+Compatible.mm"; path = "objc/WCDB/interface/compatible/WCTTransaction+Compatible.mm"; sourceTree = "<group>"; };
-		7EB347A943CCCC3EC970A6949004529B /* WCTInterface+Convenient.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTInterface+Convenient.mm"; path = "objc/WCDB/interface/convenient/WCTInterface+Convenient.mm"; sourceTree = "<group>"; };
+		7EAF3E589443D5C19E4E64B07384BAB2 /* WCTTransaction+Compatible.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTTransaction+Compatible.mm"; path = "objc/WCDB/interface/compatible/WCTTransaction+Compatible.mm"; sourceTree = "<group>"; };
+		7EB347A943CCCC3EC970A6949004529B /* WCTInterface+Convenient.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTInterface+Convenient.mm"; path = "objc/WCDB/interface/convenient/WCTInterface+Convenient.mm"; sourceTree = "<group>"; };
 		7EE08306B1E65FB353148BEB21989C58 /* rwlock.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = rwlock.hpp; path = objc/WCDB/util/rwlock.hpp; sourceTree = "<group>"; };
-		7EF012757335C17349425FC2BE7821E7 /* sqliterk_os.c */ = {isa = PBXFileReference; includeInIndex = 1; name = sqliterk_os.c; path = repair/sqliterk_os.c; sourceTree = "<group>"; };
+		7EF012757335C17349425FC2BE7821E7 /* sqliterk_os.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = sqliterk_os.c; path = repair/sqliterk_os.c; sourceTree = "<group>"; };
 		7F52DFFBAE0DC2FDCCCB9B56D715B339 /* IQUIViewController+Additions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "IQUIViewController+Additions.h"; path = "IQKeyboardManager/Categories/IQUIViewController+Additions.h"; sourceTree = "<group>"; };
-		7F673D2D239B573AEA81A72A1131D7F8 /* mz_crypt_apple.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mz_crypt_apple.c; path = SSZipArchive/minizip/mz_crypt_apple.c; sourceTree = "<group>"; };
-		7F8062D749B9F5DA7B396DD422C4D142 /* WCTInterface+Core.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTInterface+Core.mm"; path = "objc/WCDB/interface/core/WCTInterface+Core.mm"; sourceTree = "<group>"; };
+		7F673D2D239B573AEA81A72A1131D7F8 /* mz_crypt_apple.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mz_crypt_apple.c; path = SSZipArchive/minizip/mz_crypt_apple.c; sourceTree = "<group>"; };
+		7F8062D749B9F5DA7B396DD422C4D142 /* WCTInterface+Core.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTInterface+Core.mm"; path = "objc/WCDB/interface/core/WCTInterface+Core.mm"; sourceTree = "<group>"; };
 		7F960083BDF7D66CDF5C3E4A995BA108 /* WCTMaster+WCTTableCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTMaster+WCTTableCoding.h"; path = "objc/WCDB/interface/builtin/WCTMaster+WCTTableCoding.h"; sourceTree = "<group>"; };
-		7FABF6388BAC03AC751CA5AB14B20257 /* crypto_impl.c */ = {isa = PBXFileReference; includeInIndex = 1; name = crypto_impl.c; path = src/crypto_impl.c; sourceTree = "<group>"; };
+		7FABF6388BAC03AC751CA5AB14B20257 /* crypto_impl.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = crypto_impl.c; path = src/crypto_impl.c; sourceTree = "<group>"; };
 		7FBFE71037670A52E7F7E86E0EC24EFD /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLRequestSerialization.h; path = AFNetworking/AFURLRequestSerialization.h; sourceTree = "<group>"; };
 		7FDAC1F9CB0C91E310C836DB1502A940 /* crypto.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = crypto.h; path = src/crypto.h; sourceTree = "<group>"; };
 		800E8C31BE64F072B4F7224A8B8FE14C /* UIView+WebCacheOperation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView+WebCacheOperation.m"; path = "SDWebImage/Core/UIView+WebCacheOperation.m"; sourceTree = "<group>"; };
@@ -2075,46 +2076,46 @@
 		8160FA080F486322D9CB67E3BB0212F7 /* NSObject+YYModel.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+YYModel.h"; path = "YYModel/NSObject+YYModel.h"; sourceTree = "<group>"; };
 		819020D4C20571B1039AD82A3CFBC691 /* LOTShapePath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTShapePath.h; path = "lottie-ios/Classes/Models/LOTShapePath.h"; sourceTree = "<group>"; };
 		81F45AB7CFEAB78A788F64069448A23A /* SDImageIOAnimatedCoderInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDImageIOAnimatedCoderInternal.h; path = SDWebImage/Private/SDImageIOAnimatedCoderInternal.h; sourceTree = "<group>"; };
-		82191349388E18293C6E8DDE04121F6A /* fts3_snippet.c */ = {isa = PBXFileReference; includeInIndex = 1; name = fts3_snippet.c; path = ext/fts3/fts3_snippet.c; sourceTree = "<group>"; };
+		82191349388E18293C6E8DDE04121F6A /* fts3_snippet.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fts3_snippet.c; path = ext/fts3/fts3_snippet.c; sourceTree = "<group>"; };
 		821AC473EA0F3038BE1A075898DEBBE1 /* MJProperty.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MJProperty.m; path = MJExtension/MJProperty.m; sourceTree = "<group>"; };
 		82312450BCF8B713B2CA42D14F3B3F29 /* OpenSSL-Universal.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "OpenSSL-Universal.release.xcconfig"; sourceTree = "<group>"; };
-		824206978C9C364EB6C6C79BE8462728 /* fts3_porter.c */ = {isa = PBXFileReference; includeInIndex = 1; name = fts3_porter.c; path = ext/fts3/fts3_porter.c; sourceTree = "<group>"; };
+		824206978C9C364EB6C6C79BE8462728 /* fts3_porter.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fts3_porter.c; path = ext/fts3/fts3_porter.c; sourceTree = "<group>"; };
 		82896771CBA1C7F8F27D30C585001D60 /* LOTHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTHelpers.h; path = "lottie-ios/Classes/Extensions/LOTHelpers.h"; sourceTree = "<group>"; };
 		82B66B512256708AB54E4BFE6CFDF9F2 /* SDImageIOAnimatedCoder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDImageIOAnimatedCoder.h; path = SDWebImage/Core/SDImageIOAnimatedCoder.h; sourceTree = "<group>"; };
 		82D498CB6527730DA44592A33BCC3378 /* NSString+MJExtension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+MJExtension.h"; path = "MJExtension/NSString+MJExtension.h"; sourceTree = "<group>"; };
 		82E321324F58C91512F199C56C842A0A /* tokenizer.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = tokenizer.cpp; path = objc/WCDB/core/tokenizer.cpp; sourceTree = "<group>"; };
-		82EE3FD163E7F7E40B1206284E3B196C /* mz_os.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mz_os.c; path = SSZipArchive/minizip/mz_os.c; sourceTree = "<group>"; };
+		82EE3FD163E7F7E40B1206284E3B196C /* mz_os.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mz_os.c; path = SSZipArchive/minizip/mz_os.c; sourceTree = "<group>"; };
 		82F805C48BEE5AD87F2984595A77DCD1 /* SVIndefiniteAnimatedView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SVIndefiniteAnimatedView.m; path = SVProgressHUD/SVIndefiniteAnimatedView.m; sourceTree = "<group>"; };
 		83249713BCB2075501C726E9DBC95168 /* mz_strm_zlib.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mz_strm_zlib.h; path = SSZipArchive/minizip/mz_strm_zlib.h; sourceTree = "<group>"; };
 		83FCED36911983108CE76426B9823454 /* YCTreeMenuProtocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCTreeMenuProtocol.h; path = YCEasyTool/Classes/UI/TreeMenu/YCTreeMenuProtocol.h; sourceTree = "<group>"; };
 		84056E116E3CB4DE471C8C1240A9D804 /* vdbe.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = vdbe.h; path = src/vdbe.h; sourceTree = "<group>"; };
 		847899E870C6BC33EA185ACEA8D0E28F /* DDASLLogCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDASLLogCapture.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDASLLogCapture.h; sourceTree = "<group>"; };
 		8483289BFF2EF8A30FEC3E14CF9DE5D5 /* LOTLayer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTLayer.h; path = "lottie-ios/Classes/Models/LOTLayer.h"; sourceTree = "<group>"; };
-		8495A7C09FDB1AF22720FBAC46829609 /* NSDate+WCTColumnCoding.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "NSDate+WCTColumnCoding.mm"; path = "objc/WCDB/interface/builtin/NSDate+WCTColumnCoding.mm"; sourceTree = "<group>"; };
+		8495A7C09FDB1AF22720FBAC46829609 /* NSDate+WCTColumnCoding.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSDate+WCTColumnCoding.mm"; path = "objc/WCDB/interface/builtin/NSDate+WCTColumnCoding.mm"; sourceTree = "<group>"; };
 		849ED4216A7B01A4603D6A73801B88AB /* SDWebImageTransition.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDWebImageTransition.m; path = SDWebImage/Core/SDWebImageTransition.m; sourceTree = "<group>"; };
 		84D49381C082CA6404845772BDAD7EFF /* NSArray+YCTools.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSArray+YCTools.m"; path = "YCEasyTool/Classes/CollectionTools/NSArray+YCTools.m"; sourceTree = "<group>"; };
-		84DD27E2166B82C1DE0C61D8A639B3D2 /* YCBase */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = YCBase; path = libYCBase.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		84DD27E2166B82C1DE0C61D8A639B3D2 /* libYCBase.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libYCBase.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		84E8115D888A95BA81946F16EA239BCA /* SVProgressAnimatedView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SVProgressAnimatedView.h; path = SVProgressHUD/SVProgressAnimatedView.h; sourceTree = "<group>"; };
 		856DDB3929C08D4E81A9784FEBB88448 /* hash.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = hash.h; path = src/hash.h; sourceTree = "<group>"; };
 		8575C453F7BFC57A4020CF8062E83A72 /* database_repair_kit.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = database_repair_kit.cpp; path = objc/WCDB/core/database_repair_kit.cpp; sourceTree = "<group>"; };
-		859411182E4F4B6C8505F4BC1D649FC4 /* vdbeaux.c */ = {isa = PBXFileReference; includeInIndex = 1; name = vdbeaux.c; path = src/vdbeaux.c; sourceTree = "<group>"; };
-		85A01882ED06DFEA2E0CE78BCDB204A7 /* SocketRocket */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = SocketRocket; path = libSocketRocket.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		85BD536F5C21FC95FF92644017C792F2 /* fts3_expr.c */ = {isa = PBXFileReference; includeInIndex = 1; name = fts3_expr.c; path = ext/fts3/fts3_expr.c; sourceTree = "<group>"; };
+		859411182E4F4B6C8505F4BC1D649FC4 /* vdbeaux.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = vdbeaux.c; path = src/vdbeaux.c; sourceTree = "<group>"; };
+		85A01882ED06DFEA2E0CE78BCDB204A7 /* libSocketRocket.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSocketRocket.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		85BD536F5C21FC95FF92644017C792F2 /* fts3_expr.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fts3_expr.c; path = ext/fts3/fts3_expr.c; sourceTree = "<group>"; };
 		860A6DCE4B005C8E9F986EBC1755AD10 /* SSZipArchive-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SSZipArchive-dummy.m"; sourceTree = "<group>"; };
 		862F5EDE67E664CFB878B95ADF808E7A /* statement_vacuum.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = statement_vacuum.hpp; path = objc/WCDB/abstract/statement_vacuum.hpp; sourceTree = "<group>"; };
 		863725EA1FA33FC8234F8EEE700190A3 /* SDWebImageError.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDWebImageError.h; path = SDWebImage/Core/SDWebImageError.h; sourceTree = "<group>"; };
 		86917A054E04778D64C51955684F0F50 /* DDContextFilterLogFormatter+Deprecated.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "DDContextFilterLogFormatter+Deprecated.h"; path = "Sources/CocoaLumberjack/include/CocoaLumberjack/DDContextFilterLogFormatter+Deprecated.h"; sourceTree = "<group>"; };
-		86FD74E4FB7D9AB069D53919BF781C66 /* treeview.c */ = {isa = PBXFileReference; includeInIndex = 1; name = treeview.c; path = src/treeview.c; sourceTree = "<group>"; };
+		86FD74E4FB7D9AB069D53919BF781C66 /* treeview.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = treeview.c; path = src/treeview.c; sourceTree = "<group>"; };
 		8715D76F00FABB8426126463D9C1FE14 /* statement_savepoint.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = statement_savepoint.hpp; path = objc/WCDB/abstract/statement_savepoint.hpp; sourceTree = "<group>"; };
 		872E7E6A59F1D42BAB54E678A88FA8CB /* YYMemoryCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = YYMemoryCache.m; path = YYCache/YYMemoryCache.m; sourceTree = "<group>"; };
 		87311EA54E087F3824F2145A56C37418 /* SDImageGraphics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDImageGraphics.h; path = SDWebImage/Core/SDImageGraphics.h; sourceTree = "<group>"; };
 		878A6647627B699C15D906B629315621 /* JSONAPI.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = JSONAPI.h; path = JSONModel/JSONModelNetworking/JSONAPI.h; sourceTree = "<group>"; };
 		87B80B23AEB547BF394CBF6BE5D8EAEA /* SRSIMDHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SRSIMDHelpers.m; path = SocketRocket/Internal/Utilities/SRSIMDHelpers.m; sourceTree = "<group>"; };
-		884437E1EAD70DD7DB65867FAA81A9A5 /* wal.c */ = {isa = PBXFileReference; includeInIndex = 1; name = wal.c; path = src/wal.c; sourceTree = "<group>"; };
+		884437E1EAD70DD7DB65867FAA81A9A5 /* wal.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = wal.c; path = src/wal.c; sourceTree = "<group>"; };
 		884C3B678C31914A1CFDFE4BD03AD917 /* WCTDatabase+Compatible.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTDatabase+Compatible.h"; path = "objc/WCDB/interface/compatible/WCTDatabase+Compatible.h"; sourceTree = "<group>"; };
 		88704B709C44394824E94182E4AB470C /* DDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDAbstractDatabaseLogger.m; path = Sources/CocoaLumberjack/DDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
-		8879D806A3C9D2BE8B14C1FD74191780 /* ISO8601 */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = ISO8601; path = libISO8601.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		88F09D78588D63F34F6FAE9765A70E0D /* NSNumber+WCTColumnCoding.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "NSNumber+WCTColumnCoding.mm"; path = "objc/WCDB/interface/builtin/NSNumber+WCTColumnCoding.mm"; sourceTree = "<group>"; };
+		8879D806A3C9D2BE8B14C1FD74191780 /* libISO8601.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libISO8601.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		88F09D78588D63F34F6FAE9765A70E0D /* NSNumber+WCTColumnCoding.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSNumber+WCTColumnCoding.mm"; path = "objc/WCDB/interface/builtin/NSNumber+WCTColumnCoding.mm"; sourceTree = "<group>"; };
 		89614EEA4CF04D5DD41FAA04D6FF65A2 /* SDImageAssetManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDImageAssetManager.m; path = SDWebImage/Private/SDImageAssetManager.m; sourceTree = "<group>"; };
 		897D780D4A14ADD9E89D4075927AB484 /* WCTDelete+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTDelete+Private.h"; path = "objc/WCDB/interface/chaincall/WCTDelete+Private.h"; sourceTree = "<group>"; };
 		8A1562F118D70058A95CCA60FA89C849 /* WCTResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTResult.h; path = objc/WCDB/interface/orm/coding/WCTResult.h; sourceTree = "<group>"; };
@@ -2123,13 +2124,13 @@
 		8A8BC4BE7B7E3D5F0AEF2B16E1EC3C83 /* MASConstraintMaker.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = MASConstraintMaker.m; path = Masonry/MASConstraintMaker.m; sourceTree = "<group>"; };
 		8AFB1CF41958AC26E9AF7C5D9E809937 /* LOTKeypath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTKeypath.h; path = "lottie-ios/Classes/PublicHeaders/LOTKeypath.h"; sourceTree = "<group>"; };
 		8B1D02572900F629AE274834A06EE741 /* NSObject+MJClass.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSObject+MJClass.m"; path = "MJExtension/NSObject+MJClass.m"; sourceTree = "<group>"; };
-		8B6CF5C20C32EE9F7F0862FF892524DE /* SDCycleScrollView */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = SDCycleScrollView; path = libSDCycleScrollView.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8BDBB20430357C1C246D4146A5AB15D7 /* NSData+WCTColumnCoding.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "NSData+WCTColumnCoding.mm"; path = "objc/WCDB/interface/builtin/NSData+WCTColumnCoding.mm"; sourceTree = "<group>"; };
+		8B6CF5C20C32EE9F7F0862FF892524DE /* libSDCycleScrollView.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSDCycleScrollView.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8BDBB20430357C1C246D4146A5AB15D7 /* NSData+WCTColumnCoding.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSData+WCTColumnCoding.mm"; path = "objc/WCDB/interface/builtin/NSData+WCTColumnCoding.mm"; sourceTree = "<group>"; };
 		8BE70F3A87782FCBC113F1ED3CEC5F72 /* NSRunLoop+SRWebSocketPrivate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSRunLoop+SRWebSocketPrivate.h"; path = "SocketRocket/Internal/NSRunLoop+SRWebSocketPrivate.h"; sourceTree = "<group>"; };
 		8C8F1F2762E2148449E4A96C3EE05462 /* column_def.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = column_def.hpp; path = objc/WCDB/abstract/column_def.hpp; sourceTree = "<group>"; };
 		8CB07807150F08BFE6D099617BA6531B /* WCTConstraintBinding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTConstraintBinding.h; path = objc/WCDB/interface/orm/binding/WCTConstraintBinding.h; sourceTree = "<group>"; };
 		8D0BF5E81885411FCC5B7B9E573D558A /* WCTBinding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTBinding.h; path = objc/WCDB/interface/orm/binding/WCTBinding.h; sourceTree = "<group>"; };
-		8D3AB58F34A74B85FB672339450991C2 /* threads.c */ = {isa = PBXFileReference; includeInIndex = 1; name = threads.c; path = src/threads.c; sourceTree = "<group>"; };
+		8D3AB58F34A74B85FB672339450991C2 /* threads.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = threads.c; path = src/threads.c; sourceTree = "<group>"; };
 		8D592331851377263AF61EFF89BF1531 /* YCBase-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "YCBase-prefix.pch"; sourceTree = "<group>"; };
 		8D87692ECDC30345BCEA3E8653B637DE /* constraint_table.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = constraint_table.cpp; path = objc/WCDB/abstract/constraint_table.cpp; sourceTree = "<group>"; };
 		8DA0AF3772038E2E4F5633EC658EF1F7 /* file.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = file.hpp; path = objc/WCDB/util/file.hpp; sourceTree = "<group>"; };
@@ -2143,23 +2144,23 @@
 		8EEF88FB1C711F8425297A4DACDE519C /* YCBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCBase.h; path = YCBase/Classes/YCBase.h; sourceTree = "<group>"; };
 		8F01A529F06EBD8F41FFC9D45D067904 /* statement_create_index.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = statement_create_index.hpp; path = objc/WCDB/abstract/statement_create_index.hpp; sourceTree = "<group>"; };
 		8F2DFE2F853C115190A878A87F55C397 /* fts5.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = fts5.h; sourceTree = "<group>"; };
-		8F825634C556E480B86AC6FA3FDE916A /* status.c */ = {isa = PBXFileReference; includeInIndex = 1; name = status.c; path = src/status.c; sourceTree = "<group>"; };
+		8F825634C556E480B86AC6FA3FDE916A /* status.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = status.c; path = src/status.c; sourceTree = "<group>"; };
 		8FAA1FE3B4321215CC87B47C54FF7A4C /* NSImage+Compatibility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSImage+Compatibility.h"; path = "SDWebImage/Core/NSImage+Compatibility.h"; sourceTree = "<group>"; };
 		8FBE3CCD652F874C6C20682256DB11FA /* SDAnimatedImageView+WebCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "SDAnimatedImageView+WebCache.m"; path = "SDWebImage/Core/SDAnimatedImageView+WebCache.m"; sourceTree = "<group>"; };
 		8FF2247AA5CB6DB42BBC510FB2B2BFF6 /* concurrent_list.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = concurrent_list.hpp; path = objc/WCDB/util/concurrent_list.hpp; sourceTree = "<group>"; };
 		9042DC4589DF8CF019AE7B8E602DE4AB /* SRHTTPConnectMessage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SRHTTPConnectMessage.m; path = SocketRocket/Internal/Utilities/SRHTTPConnectMessage.m; sourceTree = "<group>"; };
-		90A427D8FD54486A62B589BCA27A0112 /* WCTDatabase+RepairKit.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTDatabase+RepairKit.mm"; path = "objc/WCDB/interface/database/WCTDatabase+RepairKit.mm"; sourceTree = "<group>"; };
+		90A427D8FD54486A62B589BCA27A0112 /* WCTDatabase+RepairKit.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTDatabase+RepairKit.mm"; path = "objc/WCDB/interface/database/WCTDatabase+RepairKit.mm"; sourceTree = "<group>"; };
 		90D0AA9444D708ADF6FD45347DE1FCDC /* sqliterk_crypto.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sqliterk_crypto.h; path = repair/sqliterk_crypto.h; sourceTree = "<group>"; };
-		910138BBF0C5F16369EDBFB4A89A0350 /* walker.c */ = {isa = PBXFileReference; includeInIndex = 1; name = walker.c; path = src/walker.c; sourceTree = "<group>"; };
+		910138BBF0C5F16369EDBFB4A89A0350 /* walker.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = walker.c; path = src/walker.c; sourceTree = "<group>"; };
 		9135CEF47CDC66900DD64D6798C5D741 /* JSONHTTPClient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = JSONHTTPClient.h; path = JSONModel/JSONModelNetworking/JSONHTTPClient.h; sourceTree = "<group>"; };
-		914547CA5B6B84180F10718AC2B729C0 /* hash.c */ = {isa = PBXFileReference; includeInIndex = 1; name = hash.c; path = src/hash.c; sourceTree = "<group>"; };
-		919A66F06CE020EC402EB5E3A1D27B64 /* crypto.c */ = {isa = PBXFileReference; includeInIndex = 1; name = crypto.c; path = src/crypto.c; sourceTree = "<group>"; };
+		914547CA5B6B84180F10718AC2B729C0 /* hash.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = hash.c; path = src/hash.c; sourceTree = "<group>"; };
+		919A66F06CE020EC402EB5E3A1D27B64 /* crypto.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = crypto.c; path = src/crypto.c; sourceTree = "<group>"; };
 		91A2D86CBE08C6D95F2721360F1BD5B0 /* SAMKeychain.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SAMKeychain.debug.xcconfig; sourceTree = "<group>"; };
-		91B23470DEB9A986332BEB5034234BC7 /* SSZipArchive */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = SSZipArchive; path = libSSZipArchive.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		91B28373693C401C079ED1E40928EDD0 /* prepare.c */ = {isa = PBXFileReference; includeInIndex = 1; name = prepare.c; path = src/prepare.c; sourceTree = "<group>"; };
-		91EDA2B8E8017DF38CBB5A84D7C18CBD /* pcache1.c */ = {isa = PBXFileReference; includeInIndex = 1; name = pcache1.c; path = src/pcache1.c; sourceTree = "<group>"; };
+		91B23470DEB9A986332BEB5034234BC7 /* libSSZipArchive.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSSZipArchive.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		91B28373693C401C079ED1E40928EDD0 /* prepare.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = prepare.c; path = src/prepare.c; sourceTree = "<group>"; };
+		91EDA2B8E8017DF38CBB5A84D7C18CBD /* pcache1.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = pcache1.c; path = src/pcache1.c; sourceTree = "<group>"; };
 		92117A3E2771AF0C15B49A23FE6F1413 /* NSLayoutConstraint+MASDebugAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSLayoutConstraint+MASDebugAdditions.h"; path = "Masonry/NSLayoutConstraint+MASDebugAdditions.h"; sourceTree = "<group>"; };
-		924A1E8C65CE5B8754AB8FDE9162A20E /* WCTChainCall.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTChainCall.mm; path = objc/WCDB/interface/chaincall/WCTChainCall.mm; sourceTree = "<group>"; };
+		924A1E8C65CE5B8754AB8FDE9162A20E /* WCTChainCall.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTChainCall.mm; path = objc/WCDB/interface/chaincall/WCTChainCall.mm; sourceTree = "<group>"; };
 		925AB1F2244CE8D2EA086B9BA1E06BAB /* SDFileAttributeHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDFileAttributeHelper.h; path = SDWebImage/Private/SDFileAttributeHelper.h; sourceTree = "<group>"; };
 		92AB7C94AE7160B3F1F400088030980F /* statement_savepoint.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_savepoint.cpp; path = objc/WCDB/abstract/statement_savepoint.cpp; sourceTree = "<group>"; };
 		92AC2E4C92968B12F21502D78C3D8D45 /* ISO8601-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ISO8601-prefix.pch"; sourceTree = "<group>"; };
@@ -2168,34 +2169,34 @@
 		939DDB75E7AC754C024181772ADA9F3B /* SDDisplayLink.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDDisplayLink.m; path = SDWebImage/Private/SDDisplayLink.m; sourceTree = "<group>"; };
 		93ED9A2BA8FF21226498AA5CF4DFD6BC /* Pods-EulixSpace-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-EulixSpace-resources.sh"; sourceTree = "<group>"; };
 		93EF2EEA61601591D15F3A3DA7B32772 /* parse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = parse.h; sourceTree = "<group>"; };
-		95095ADF9C57997019E31C383382FC63 /* WCTTokenizer+WCDB.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTTokenizer+WCDB.mm"; path = "objc/WCDB/interface/fts/WCTTokenizer+WCDB.mm"; sourceTree = "<group>"; };
+		95095ADF9C57997019E31C383382FC63 /* WCTTokenizer+WCDB.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTTokenizer+WCDB.mm"; path = "objc/WCDB/interface/fts/WCTTokenizer+WCDB.mm"; sourceTree = "<group>"; };
 		95898C2788BB2CC254412BD8E0DECFCA /* path.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = path.hpp; path = objc/WCDB/util/path.hpp; sourceTree = "<group>"; };
-		95EC021801D9E0D5583791FDCA2ECFA3 /* rtree.c */ = {isa = PBXFileReference; includeInIndex = 1; name = rtree.c; path = ext/rtree/rtree.c; sourceTree = "<group>"; };
+		95EC021801D9E0D5583791FDCA2ECFA3 /* rtree.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = rtree.c; path = ext/rtree/rtree.c; sourceTree = "<group>"; };
 		9632F6FBF2BD95416395ABC0AACE8107 /* Masonry.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Masonry.h; path = Masonry/Masonry.h; sourceTree = "<group>"; };
 		963D89B67A9E5B7094EC6BB3447AC31E /* SSZipArchive-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SSZipArchive-prefix.pch"; sourceTree = "<group>"; };
 		96663C1791B864E09294FC8BDFA59C07 /* ticker.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = ticker.cpp; path = objc/WCDB/util/ticker.cpp; sourceTree = "<group>"; };
 		967C3E0DBA882E45A4C511E519BF2983 /* YCForeverProtocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCForeverProtocol.h; path = YCEasyTool/Classes/Forever/YCForeverProtocol.h; sourceTree = "<group>"; };
-		968A0582847B458EA61E0E423F91CEBB /* WCTDatabase.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTDatabase.mm; path = objc/WCDB/interface/declare/WCTDatabase.mm; sourceTree = "<group>"; };
+		968A0582847B458EA61E0E423F91CEBB /* WCTDatabase.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTDatabase.mm; path = objc/WCDB/interface/declare/WCTDatabase.mm; sourceTree = "<group>"; };
 		96AD567957A16E4D0ACEF923E6D1826F /* YYCache-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "YYCache-prefix.pch"; sourceTree = "<group>"; };
 		96DA5161AC2DD5C43DFC6ABFD4FFB2A2 /* WCTProperty.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTProperty.h; path = objc/WCDB/interface/orm/coding/WCTProperty.h; sourceTree = "<group>"; };
 		96FC75BEFDD198CD23782DC0719EBC07 /* YYKVStorage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YYKVStorage.h; path = YYCache/YYKVStorage.h; sourceTree = "<group>"; };
-		9722CAE9E66AF0D9F42FAD54A954DEC6 /* date.c */ = {isa = PBXFileReference; includeInIndex = 1; name = date.c; path = src/date.c; sourceTree = "<group>"; };
+		9722CAE9E66AF0D9F42FAD54A954DEC6 /* date.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = date.c; path = src/date.c; sourceTree = "<group>"; };
 		97993AA3AFF2617719D1B3EF236B1BCC /* WCDBOptimizedSQLCipher-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "WCDBOptimizedSQLCipher-dummy.m"; sourceTree = "<group>"; };
 		979D02AE9CCE6F90D1AE07222DA9A837 /* GCDWebServerDataResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GCDWebServerDataResponse.h; path = GCDWebServer/Responses/GCDWebServerDataResponse.h; sourceTree = "<group>"; };
 		97ED9B4C47E017EE4764A0E87B977172 /* WCTSelectBase+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTSelectBase+Private.h"; path = "objc/WCDB/interface/chaincall/WCTSelectBase+Private.h"; sourceTree = "<group>"; };
 		982DC164F922279EA9E76EF5A3D1890D /* NSObject+MJCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+MJCoding.h"; path = "MJExtension/NSObject+MJCoding.h"; sourceTree = "<group>"; };
 		98415FBE537278FBB232E2A309A419FD /* IQKeyboardManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IQKeyboardManager.m; path = IQKeyboardManager/IQKeyboardManager.m; sourceTree = "<group>"; };
 		984F4ADABC824BD5949DBEBBB9F346CD /* Reachability-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Reachability-dummy.m"; sourceTree = "<group>"; };
-		98527D7196957AAB07B79E2E2AFDE23E /* IQKeyboardManager */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = IQKeyboardManager; path = libIQKeyboardManager.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		98527D7196957AAB07B79E2E2AFDE23E /* libIQKeyboardManager.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libIQKeyboardManager.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9881C00212A34CB092CE429BD7109FD6 /* FLAnimatedImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FLAnimatedImage.h; path = FLAnimatedImage/include/FLAnimatedImage.h; sourceTree = "<group>"; };
 		98FD6D60F074A1506305E6CAE1FE6CCF /* MJExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = MJExtension.release.xcconfig; sourceTree = "<group>"; };
 		99536419620673C6279C205B84F09368 /* SVProgressHUD.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SVProgressHUD.m; path = SVProgressHUD/SVProgressHUD.m; sourceTree = "<group>"; };
-		9953CBBDB2470C048F50A8457EEE31A7 /* fts3_tokenizer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = fts3_tokenizer.c; path = ext/fts3/fts3_tokenizer.c; sourceTree = "<group>"; };
+		9953CBBDB2470C048F50A8457EEE31A7 /* fts3_tokenizer.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fts3_tokenizer.c; path = ext/fts3/fts3_tokenizer.c; sourceTree = "<group>"; };
 		996D0CC1E2EF3413204631CA5C6085AB /* SRIOConsumerPool.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SRIOConsumerPool.m; path = SocketRocket/Internal/IOConsumer/SRIOConsumerPool.m; sourceTree = "<group>"; };
 		99940AA9FA97729C029AA3826195FC92 /* WCTTransaction+Compatible.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTTransaction+Compatible.h"; path = "objc/WCDB/interface/compatible/WCTTransaction+Compatible.h"; sourceTree = "<group>"; };
-		99B598160417F93311341EF773BAA3D6 /* WCTConstraintBinding.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTConstraintBinding.mm; path = objc/WCDB/interface/orm/binding/WCTConstraintBinding.mm; sourceTree = "<group>"; };
+		99B598160417F93311341EF773BAA3D6 /* WCTConstraintBinding.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTConstraintBinding.mm; path = objc/WCDB/interface/orm/binding/WCTConstraintBinding.mm; sourceTree = "<group>"; };
 		99D92A0B904A60C7AD9EB0AD3AA20404 /* statement_create_virtual_table.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = statement_create_virtual_table.hpp; path = objc/WCDB/abstract/statement_create_virtual_table.hpp; sourceTree = "<group>"; };
-		9A7E1652E4EEC5308F20453DD56AE7A5 /* mem2.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mem2.c; path = src/mem2.c; sourceTree = "<group>"; };
+		9A7E1652E4EEC5308F20453DD56AE7A5 /* mem2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mem2.c; path = src/mem2.c; sourceTree = "<group>"; };
 		9AB0589B9E7CEBFFCF4576B74A83E76C /* WCTObjCAccessor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTObjCAccessor.h; path = objc/WCDB/interface/orm/accessor/WCTObjCAccessor.h; sourceTree = "<group>"; };
 		9ADECB43C98E6F4E7EDBC37FD33E20AE /* SRSecurityPolicy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SRSecurityPolicy.m; path = SocketRocket/SRSecurityPolicy.m; sourceTree = "<group>"; };
 		9AFCA017E149F7A8D5C218E730556C49 /* SDCycleScrollView.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SDCycleScrollView.debug.xcconfig; sourceTree = "<group>"; };
@@ -2207,47 +2208,47 @@
 		9C2FA6466CBEEDDE2FA5602415C087CE /* MJPropertyType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MJPropertyType.h; path = MJExtension/MJPropertyType.h; sourceTree = "<group>"; };
 		9C70F4ACBE52C08DBC354F5CD0113258 /* GCDWebServerURLEncodedFormRequest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GCDWebServerURLEncodedFormRequest.h; path = GCDWebServer/Requests/GCDWebServerURLEncodedFormRequest.h; sourceTree = "<group>"; };
 		9CCE779A5965E2E23B47025FE25E3DB0 /* SDImageLoadersManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDImageLoadersManager.m; path = SDWebImage/Core/SDImageLoadersManager.m; sourceTree = "<group>"; };
-		9CDD266E1AEBFD162A3507C87D2D7C71 /* mz_strm.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mz_strm.c; path = SSZipArchive/minizip/mz_strm.c; sourceTree = "<group>"; };
-		9CF0D5A2696A05EC20516D05B7441C5E /* WCTDatabase+Table.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTDatabase+Table.mm"; path = "objc/WCDB/interface/table/WCTDatabase+Table.mm"; sourceTree = "<group>"; };
-		9D66FE95C92BC6D3E6880ED4E26C3D0C /* mem3.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mem3.c; path = src/mem3.c; sourceTree = "<group>"; };
+		9CDD266E1AEBFD162A3507C87D2D7C71 /* mz_strm.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mz_strm.c; path = SSZipArchive/minizip/mz_strm.c; sourceTree = "<group>"; };
+		9CF0D5A2696A05EC20516D05B7441C5E /* WCTDatabase+Table.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTDatabase+Table.mm"; path = "objc/WCDB/interface/table/WCTDatabase+Table.mm"; sourceTree = "<group>"; };
+		9D66FE95C92BC6D3E6880ED4E26C3D0C /* mem3.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mem3.c; path = src/mem3.c; sourceTree = "<group>"; };
 		9D6A1727BDA8865F7B38793777091658 /* LOTAnimatorNode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTAnimatorNode.h; path = "lottie-ios/Classes/RenderSystem/LOTAnimatorNode.h"; sourceTree = "<group>"; };
 		9D781A571311979D2E259E22FC43F189 /* LOTRenderGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTRenderGroup.m; path = "lottie-ios/Classes/RenderSystem/RenderNodes/LOTRenderGroup.m"; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9DDF0C868FB4B5C7A87695E8FBD23B2C /* TAAbstractDotView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = TAAbstractDotView.m; path = SDCycleScrollView/Lib/SDCycleScrollView/PageControl/TAAbstractDotView.m; sourceTree = "<group>"; };
 		9E0859EA07A9A67E98DC02532A43BB5C /* WCTCoding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTCoding.h; path = objc/WCDB/interface/orm/coding/WCTCoding.h; sourceTree = "<group>"; };
 		9E247DCF62B9CD26DD38800A252D2BA6 /* statement_explain.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = statement_explain.hpp; path = objc/WCDB/abstract/statement_explain.hpp; sourceTree = "<group>"; };
-		9E60E3B1708CE03CB24F9BD7BA5F3C7B /* btree.c */ = {isa = PBXFileReference; includeInIndex = 1; name = btree.c; path = src/btree.c; sourceTree = "<group>"; };
+		9E60E3B1708CE03CB24F9BD7BA5F3C7B /* btree.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = btree.c; path = src/btree.c; sourceTree = "<group>"; };
 		9E8283CCF62EF0867304FF1090F70969 /* JSONAPI.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = JSONAPI.m; path = JSONModel/JSONModelNetworking/JSONAPI.m; sourceTree = "<group>"; };
 		9EFF292876FFC2EDD0A8DDA6DDD39AD9 /* SDGraphicsImageRenderer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDGraphicsImageRenderer.h; path = SDWebImage/Core/SDGraphicsImageRenderer.h; sourceTree = "<group>"; };
 		9F024F76CF446DD9CF02C6458F5B514D /* sqlite3rtree.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sqlite3rtree.h; path = ext/rtree/sqlite3rtree.h; sourceTree = "<group>"; };
 		9FDB619D5498C5A5542614FC4702879C /* SDAnimatedImageRep.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDAnimatedImageRep.m; path = SDWebImage/Core/SDAnimatedImageRep.m; sourceTree = "<group>"; };
-		A0225672BF6E5758FA4303E0C8AEF949 /* alter.c */ = {isa = PBXFileReference; includeInIndex = 1; name = alter.c; path = src/alter.c; sourceTree = "<group>"; };
+		A0225672BF6E5758FA4303E0C8AEF949 /* alter.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = alter.c; path = src/alter.c; sourceTree = "<group>"; };
 		A041EA365B512B82F689AC9F0435E241 /* IQUIViewController+Additions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "IQUIViewController+Additions.m"; path = "IQKeyboardManager/Categories/IQUIViewController+Additions.m"; sourceTree = "<group>"; };
 		A09214D01CA1B5BD9C3B4A9F55565484 /* IQKeyboardManager-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IQKeyboardManager-prefix.pch"; sourceTree = "<group>"; };
 		A10452733A3AFB29C1D2F56771AFC8AD /* pager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = pager.h; path = src/pager.h; sourceTree = "<group>"; };
 		A1991AA60F1DABCDF5A4094C87A6FBEC /* YCGridView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCGridView.h; path = YCEasyTool/Classes/UI/Grid/YCGridView.h; sourceTree = "<group>"; };
 		A1AF94832A26EB3F659787476D9CA8D0 /* JSONModel.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = JSONModel.debug.xcconfig; sourceTree = "<group>"; };
-		A1C587D8C5903197DE5C9F17B5405546 /* mz_strm_buf.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mz_strm_buf.c; path = SSZipArchive/minizip/mz_strm_buf.c; sourceTree = "<group>"; };
+		A1C587D8C5903197DE5C9F17B5405546 /* mz_strm_buf.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mz_strm_buf.c; path = SSZipArchive/minizip/mz_strm_buf.c; sourceTree = "<group>"; };
 		A224EDBC8D9CA49D17794A0C316333CF /* NSRunLoop+SRWebSocket.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSRunLoop+SRWebSocket.m"; path = "SocketRocket/NSRunLoop+SRWebSocket.m"; sourceTree = "<group>"; };
 		A26C5972B78D4A714A7F75AC5925C38C /* YYKVStorage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = YYKVStorage.m; path = YYCache/YYKVStorage.m; sourceTree = "<group>"; };
 		A29C267FF19F09FCE3B8CF188DBA23AB /* UIColor+SDHexString.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIColor+SDHexString.h"; path = "SDWebImage/Private/UIColor+SDHexString.h"; sourceTree = "<group>"; };
 		A2A4DB6F6AC226FC03553BC9FAE48466 /* YCSegmentedControl.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = YCSegmentedControl.m; path = YCEasyTool/Classes/UI/Segment/YCSegmentedControl.m; sourceTree = "<group>"; };
-		A2E93CAD948429E29D85139AB497305A /* sqliterk.c */ = {isa = PBXFileReference; includeInIndex = 1; name = sqliterk.c; path = repair/sqliterk.c; sourceTree = "<group>"; };
+		A2E93CAD948429E29D85139AB497305A /* sqliterk.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = sqliterk.c; path = repair/sqliterk.c; sourceTree = "<group>"; };
 		A3159E20C983C1B085E6B2D3794C344C /* file.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = file.cpp; path = objc/WCDB/util/file.cpp; sourceTree = "<group>"; };
 		A3A94F9AC30F1FC3FA91AABD7A3C8147 /* SDImageFrame.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDImageFrame.h; path = SDWebImage/Core/SDImageFrame.h; sourceTree = "<group>"; };
 		A3AA16B315F8CB662DD416D62AE40EF9 /* WCTInterface+Convenient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTInterface+Convenient.h"; path = "objc/WCDB/interface/convenient/WCTInterface+Convenient.h"; sourceTree = "<group>"; };
 		A3DC987785915FCA3564CC5769D123F1 /* sqliterk_column.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sqliterk_column.h; path = repair/sqliterk_column.h; sourceTree = "<group>"; };
 		A4007B000375FE1389E91B7B86ADF52A /* fts3.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = fts3.h; path = ext/fts3/fts3.h; sourceTree = "<group>"; };
-		A43E2CF903EE130CC285248BE4A15FC0 /* mz_strm_os_posix.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mz_strm_os_posix.c; path = SSZipArchive/minizip/mz_strm_os_posix.c; sourceTree = "<group>"; };
+		A43E2CF903EE130CC285248BE4A15FC0 /* mz_strm_os_posix.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mz_strm_os_posix.c; path = SSZipArchive/minizip/mz_strm_os_posix.c; sourceTree = "<group>"; };
 		A45881BC4672E3AB7357C6FA1065CAFD /* LOTComposition.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTComposition.m; path = "lottie-ios/Classes/Private/LOTComposition.m"; sourceTree = "<group>"; };
 		A459AE04B7E46C61B92C62F4B8373D25 /* handle_pool.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = handle_pool.cpp; path = objc/WCDB/core/handle_pool.cpp; sourceTree = "<group>"; };
-		A4E9E04E045F500194BBA908307CCF6D /* sqliterk_crypto.c */ = {isa = PBXFileReference; includeInIndex = 1; name = sqliterk_crypto.c; path = repair/sqliterk_crypto.c; sourceTree = "<group>"; };
-		A4FA15D44DF6BAC7550EDEED10862AA3 /* AFNetworking */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = AFNetworking; path = libAFNetworking.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A4E9E04E045F500194BBA908307CCF6D /* sqliterk_crypto.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = sqliterk_crypto.c; path = repair/sqliterk_crypto.c; sourceTree = "<group>"; };
+		A4FA15D44DF6BAC7550EDEED10862AA3 /* libAFNetworking.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAFNetworking.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A55BE807CFCBB976C7822D5B20E7ADEA /* handle_statement.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = handle_statement.cpp; path = objc/WCDB/abstract/handle_statement.cpp; sourceTree = "<group>"; };
 		A584FE7A2EE72F1BF9CC38B6145E4162 /* statement_drop_table.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_drop_table.cpp; path = objc/WCDB/abstract/statement_drop_table.cpp; sourceTree = "<group>"; };
 		A5B5E07E0D5A0A3C07C1AB20F7CA8D4B /* SVProgressHUD-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SVProgressHUD-prefix.pch"; sourceTree = "<group>"; };
-		A5B62D3A52B1FE6AD8F4D156510B52EE /* NSObject+WCTColumnCoding.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "NSObject+WCTColumnCoding.mm"; path = "objc/WCDB/interface/builtin/NSObject+WCTColumnCoding.mm"; sourceTree = "<group>"; };
-		A5E9065AE92734D19CB6B15419F03307 /* main.c */ = {isa = PBXFileReference; includeInIndex = 1; name = main.c; path = src/main.c; sourceTree = "<group>"; };
+		A5B62D3A52B1FE6AD8F4D156510B52EE /* NSObject+WCTColumnCoding.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSObject+WCTColumnCoding.mm"; path = "objc/WCDB/interface/builtin/NSObject+WCTColumnCoding.mm"; sourceTree = "<group>"; };
+		A5E9065AE92734D19CB6B15419F03307 /* main.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = main.c; path = src/main.c; sourceTree = "<group>"; };
 		A5EE635548842FE412854E3324F8E9EE /* LOTAnimatedSwitch.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTAnimatedSwitch.m; path = "lottie-ios/Classes/Private/LOTAnimatedSwitch.m"; sourceTree = "<group>"; };
 		A60109F3188F4EEAF16CC7283DAEF798 /* LOTRepeaterRenderer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTRepeaterRenderer.h; path = "lottie-ios/Classes/RenderSystem/RenderNodes/LOTRepeaterRenderer.h"; sourceTree = "<group>"; };
 		A604C3B605ACBB822DF48370772E64BE /* TADotView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = TADotView.m; path = SDCycleScrollView/Lib/SDCycleScrollView/PageControl/TADotView.m; sourceTree = "<group>"; };
@@ -2263,13 +2264,13 @@
 		A854CA09444B271DB64B58868AB1DD13 /* Pods-EulixSpaceTests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-EulixSpaceTests-resources.sh"; sourceTree = "<group>"; };
 		A88FEFF02EB08E383B5F884A3C710913 /* FLAnimatedImage.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = FLAnimatedImage.debug.xcconfig; sourceTree = "<group>"; };
 		A8917D9F419A3C6218E8A8A5E5F78A2F /* IQKeyboardManagerConstants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IQKeyboardManagerConstants.h; path = IQKeyboardManager/Constants/IQKeyboardManagerConstants.h; sourceTree = "<group>"; };
-		A89F5FA35A899D3E0625C51103B92526 /* WCTMultiSelect.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTMultiSelect.mm; path = objc/WCDB/interface/chaincall/WCTMultiSelect.mm; sourceTree = "<group>"; };
+		A89F5FA35A899D3E0625C51103B92526 /* WCTMultiSelect.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTMultiSelect.mm; path = objc/WCDB/interface/chaincall/WCTMultiSelect.mm; sourceTree = "<group>"; };
 		A8A920F535666B7521ED42ED92438704 /* statement_detach.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_detach.cpp; path = objc/WCDB/abstract/statement_detach.cpp; sourceTree = "<group>"; };
 		A8F37EBC9C7DCCF46F348EC81F7F4A0C /* LOTRepeaterRenderer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTRepeaterRenderer.m; path = "lottie-ios/Classes/RenderSystem/RenderNodes/LOTRepeaterRenderer.m"; sourceTree = "<group>"; };
 		A8FB9F029052DF33751BB11432D680A9 /* Lottie.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Lottie.h; path = "lottie-ios/Classes/PublicHeaders/Lottie.h"; sourceTree = "<group>"; };
 		A99AECAD3D4F9536FC753111686BA1DF /* LOTMaskContainer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTMaskContainer.h; path = "lottie-ios/Classes/AnimatableLayers/LOTMaskContainer.h"; sourceTree = "<group>"; };
 		AA2CB5902819EEA7714763FDD2FA3768 /* handle.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = handle.hpp; path = objc/WCDB/abstract/handle.hpp; sourceTree = "<group>"; };
-		AA5C3208D7DC24F9E5006913B3296F7B /* WCTTable.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTTable.mm; path = objc/WCDB/interface/declare/WCTTable.mm; sourceTree = "<group>"; };
+		AA5C3208D7DC24F9E5006913B3296F7B /* WCTTable.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTTable.mm; path = objc/WCDB/interface/declare/WCTTable.mm; sourceTree = "<group>"; };
 		AA756364532C70FF883C538643BDA3D0 /* statement_create_table.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_create_table.cpp; path = objc/WCDB/abstract/statement_create_table.cpp; sourceTree = "<group>"; };
 		AA987D8050A84DB88F2262E220A130AA /* statement_alter_table.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_alter_table.cpp; path = objc/WCDB/abstract/statement_alter_table.cpp; sourceTree = "<group>"; };
 		AAFAF8C9088F994C451832FE4DF74750 /* SDAssociatedObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDAssociatedObject.m; path = SDWebImage/Private/SDAssociatedObject.m; sourceTree = "<group>"; };
@@ -2282,35 +2283,35 @@
 		ADEFFF1161F7293FCDB8BD4B9C6BF5DC /* UIImage+Metadata.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Metadata.h"; path = "SDWebImage/Core/UIImage+Metadata.h"; sourceTree = "<group>"; };
 		AE024440C24D27659A937374F9D2487F /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
 		AE25F05558FB02846214E04272F3B851 /* lottie-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "lottie-ios.release.xcconfig"; sourceTree = "<group>"; };
-		AE69EF41300B4FE745885EC9BA190A8F /* btmutex.c */ = {isa = PBXFileReference; includeInIndex = 1; name = btmutex.c; path = src/btmutex.c; sourceTree = "<group>"; };
+		AE69EF41300B4FE745885EC9BA190A8F /* btmutex.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = btmutex.c; path = src/btmutex.c; sourceTree = "<group>"; };
 		AE7660104BA443077ACD0B1E0D873C05 /* GCDWebServerRequest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = GCDWebServerRequest.m; path = GCDWebServer/Core/GCDWebServerRequest.m; sourceTree = "<group>"; };
 		AE8D38C8E79E375807926A2388CC078C /* LOTColorInterpolator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTColorInterpolator.m; path = "lottie-ios/Classes/RenderSystem/InterpolatorNodes/LOTColorInterpolator.m"; sourceTree = "<group>"; };
 		AEBA9A5FDAE7B1E76F60E666157B2DDE /* YYCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YYCache.h; path = YYCache/YYCache.h; sourceTree = "<group>"; };
-		AEFCEE95871103E8D01F3901CD26F764 /* fts3_icu.c */ = {isa = PBXFileReference; includeInIndex = 1; name = fts3_icu.c; path = ext/fts3/fts3_icu.c; sourceTree = "<group>"; };
-		AF3E5B8957BA06B78025FF5F3D0D201A /* analyze.c */ = {isa = PBXFileReference; includeInIndex = 1; name = analyze.c; path = src/analyze.c; sourceTree = "<group>"; };
+		AEFCEE95871103E8D01F3901CD26F764 /* fts3_icu.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fts3_icu.c; path = ext/fts3/fts3_icu.c; sourceTree = "<group>"; };
+		AF3E5B8957BA06B78025FF5F3D0D201A /* analyze.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = analyze.c; path = src/analyze.c; sourceTree = "<group>"; };
 		AFB6EA7B37365F672EEAA02966DA4C46 /* fts_module.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = fts_module.cpp; path = objc/WCDB/abstract/fts_module.cpp; sourceTree = "<group>"; };
 		B0176C6F7E2E71D3D54C41CC4AB14A49 /* WCTTable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTTable.h; path = objc/WCDB/interface/declare/WCTTable.h; sourceTree = "<group>"; };
-		B08EB0E5038750CE93E196F86DDB3D30 /* WCTSelectBase+WCTExpr.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTSelectBase+WCTExpr.mm"; path = "objc/WCDB/interface/orm/coding/WCTSelectBase+WCTExpr.mm"; sourceTree = "<group>"; };
-		B0B214D775196BA7CA8E17E53048A493 /* SDWebImage */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = SDWebImage; path = libSDWebImage.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		B08EB0E5038750CE93E196F86DDB3D30 /* WCTSelectBase+WCTExpr.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTSelectBase+WCTExpr.mm"; path = "objc/WCDB/interface/orm/coding/WCTSelectBase+WCTExpr.mm"; sourceTree = "<group>"; };
+		B0B214D775196BA7CA8E17E53048A493 /* libSDWebImage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSDWebImage.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B13A03CA225472784B1EE88821533676 /* DDContextFilterLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDContextFilterLogFormatter.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDContextFilterLogFormatter.h; sourceTree = "<group>"; };
 		B16B0F783A53783F9726710820B091D0 /* SDImageHEICCoder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDImageHEICCoder.h; path = SDWebImage/Core/SDImageHEICCoder.h; sourceTree = "<group>"; };
-		B20AAD808CE4F16B2ACF678C7091528D /* sqlite3rbu.c */ = {isa = PBXFileReference; includeInIndex = 1; name = sqlite3rbu.c; path = ext/rbu/sqlite3rbu.c; sourceTree = "<group>"; };
+		B20AAD808CE4F16B2ACF678C7091528D /* sqlite3rbu.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = sqlite3rbu.c; path = ext/rbu/sqlite3rbu.c; sourceTree = "<group>"; };
 		B2519EDB216771B515A5BAAB1F880B48 /* fts_modules.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = fts_modules.hpp; path = objc/WCDB/abstract/fts_modules.hpp; sourceTree = "<group>"; };
 		B27B59BE918BBA4D4C555477A769E390 /* SDImageCoderHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDImageCoderHelper.h; path = SDWebImage/Core/SDImageCoderHelper.h; sourceTree = "<group>"; };
 		B2C7DA13651DBAB0B55615EBF314306B /* WCTDatabase+FTS.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTDatabase+FTS.h"; path = "objc/WCDB/interface/fts/WCTDatabase+FTS.h"; sourceTree = "<group>"; };
 		B35410C4C6E6F320D97DC478CEDC7DEF /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkReachabilityManager.h; path = AFNetworking/AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
 		B3A27D931E6F16995ED627617D0A1127 /* SDWebImageDownloaderResponseModifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDWebImageDownloaderResponseModifier.h; path = SDWebImage/Core/SDWebImageDownloaderResponseModifier.h; sourceTree = "<group>"; };
 		B3BD2A141848C93A8BBA981F4E0A59F9 /* YCEventNotifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCEventNotifier.h; path = YCEasyTool/Classes/EventNotifier/YCEventNotifier.h; sourceTree = "<group>"; };
-		B3CF92365D6AE0F35C3602CF6C0872AE /* WCDBOptimizedSQLCipher */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = WCDBOptimizedSQLCipher; path = libWCDBOptimizedSQLCipher.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		B3D647968950B93610C255FC646756E8 /* printf.c */ = {isa = PBXFileReference; includeInIndex = 1; name = printf.c; path = src/printf.c; sourceTree = "<group>"; };
+		B3CF92365D6AE0F35C3602CF6C0872AE /* libWCDBOptimizedSQLCipher.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libWCDBOptimizedSQLCipher.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		B3D647968950B93610C255FC646756E8 /* printf.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = printf.c; path = src/printf.c; sourceTree = "<group>"; };
 		B3E2FC36297E8F0F55DF30BCCF5AF71C /* FLAnimatedImageView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FLAnimatedImageView.h; path = FLAnimatedImage/include/FLAnimatedImageView.h; sourceTree = "<group>"; };
-		B45C4CE4D67B9C8F7C3B48575F3265BD /* WCTTransaction+Table.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTTransaction+Table.mm"; path = "objc/WCDB/interface/table/WCTTransaction+Table.mm"; sourceTree = "<group>"; };
+		B45C4CE4D67B9C8F7C3B48575F3265BD /* WCTTransaction+Table.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTTransaction+Table.mm"; path = "objc/WCDB/interface/table/WCTTransaction+Table.mm"; sourceTree = "<group>"; };
 		B469B2E6B04583BDAC869520D2986866 /* WCTTransaction+Statistics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTTransaction+Statistics.h"; path = "objc/WCDB/interface/statictics/WCTTransaction+Statistics.h"; sourceTree = "<group>"; };
 		B4A01C73C1C15DA81A815497B7C76415 /* MJFoundation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MJFoundation.h; path = MJExtension/MJFoundation.h; sourceTree = "<group>"; };
-		B4ED06691936A44F46101859BE00387E /* WCTProperty.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTProperty.mm; path = objc/WCDB/interface/orm/coding/WCTProperty.mm; sourceTree = "<group>"; };
+		B4ED06691936A44F46101859BE00387E /* WCTProperty.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTProperty.mm; path = objc/WCDB/interface/orm/coding/WCTProperty.mm; sourceTree = "<group>"; };
 		B52708CC4379351637F3AC6A2A7B1A1E /* mz_strm_os.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mz_strm_os.h; path = SSZipArchive/minizip/mz_strm_os.h; sourceTree = "<group>"; };
 		B542985A3842A422627536839C99158B /* CLIColor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CLIColor.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/CLIColor.h; sourceTree = "<group>"; };
-		B546C73131707D8AB1B1EB15334FB108 /* os_unix.c */ = {isa = PBXFileReference; includeInIndex = 1; name = os_unix.c; path = src/os_unix.c; sourceTree = "<group>"; };
+		B546C73131707D8AB1B1EB15334FB108 /* os_unix.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = os_unix.c; path = src/os_unix.c; sourceTree = "<group>"; };
 		B58AC17246360C465BF6024D94BB4C22 /* SDAnimatedImagePlayer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDAnimatedImagePlayer.h; path = SDWebImage/Core/SDAnimatedImagePlayer.h; sourceTree = "<group>"; };
 		B58B418319ABE5D6AF82B9721B199E77 /* YYCache.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = YYCache.debug.xcconfig; sourceTree = "<group>"; };
 		B5A18F7C3C5203A32B72803D9E059F8C /* LOTValueInterpolator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTValueInterpolator.m; path = "lottie-ios/Classes/RenderSystem/InterpolatorNodes/LOTValueInterpolator.m"; sourceTree = "<group>"; };
@@ -2323,20 +2324,20 @@
 		B658E38F949DCA0ED6F21BD75FD7CF43 /* wal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = wal.h; path = src/wal.h; sourceTree = "<group>"; };
 		B67C278301D3EC9C59F8F5E63F146D14 /* LOTValueCallback.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTValueCallback.m; path = "lottie-ios/Classes/Private/LOTValueCallback.m"; sourceTree = "<group>"; };
 		B67C67FA55A13C1F3BE0DA23BB6A3D9B /* SDWebImageCacheSerializer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDWebImageCacheSerializer.h; path = SDWebImage/Core/SDWebImageCacheSerializer.h; sourceTree = "<group>"; };
-		B68C1052A3B51DBCF7D960F898AAFA95 /* GCDWebServer */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = GCDWebServer; path = libGCDWebServer.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		B68C1052A3B51DBCF7D960F898AAFA95 /* libGCDWebServer.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libGCDWebServer.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6A415C5AECB5B4DEDF451E064288437 /* LOTLayerContainer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTLayerContainer.h; path = "lottie-ios/Classes/AnimatableLayers/LOTLayerContainer.h"; sourceTree = "<group>"; };
 		B6ACC107CC7A4EABCCED68D6B8CEA0E7 /* OpenSSL-Universal-xcframeworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "OpenSSL-Universal-xcframeworks.sh"; sourceTree = "<group>"; };
 		B7473128F41D27EF0C0DDB10B3419923 /* SDWebImagePrefetcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDWebImagePrefetcher.m; path = SDWebImage/Core/SDWebImagePrefetcher.m; sourceTree = "<group>"; };
 		B7A6262BCFD718E58BEF216BA1D3ACE9 /* SRSIMDHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SRSIMDHelpers.h; path = SocketRocket/Internal/Utilities/SRSIMDHelpers.h; sourceTree = "<group>"; };
-		B7C63728C9D8F9E652FEA90D37E8F1B7 /* table.c */ = {isa = PBXFileReference; includeInIndex = 1; name = table.c; path = src/table.c; sourceTree = "<group>"; };
-		B7C81ADE7474C0AA7949E8135768CA95 /* WCTStatistics.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTStatistics.mm; path = objc/WCDB/interface/statictics/WCTStatistics.mm; sourceTree = "<group>"; };
+		B7C63728C9D8F9E652FEA90D37E8F1B7 /* table.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = table.c; path = src/table.c; sourceTree = "<group>"; };
+		B7C81ADE7474C0AA7949E8135768CA95 /* WCTStatistics.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTStatistics.mm; path = objc/WCDB/interface/statictics/WCTStatistics.mm; sourceTree = "<group>"; };
 		B848D2FC74032FC48CAA5D3BD17F62D5 /* DDContextFilterLogFormatter+Deprecated.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "DDContextFilterLogFormatter+Deprecated.m"; path = "Sources/CocoaLumberjack/Extensions/DDContextFilterLogFormatter+Deprecated.m"; sourceTree = "<group>"; };
-		B86C1B08DCCEF5D44C608C4640680130 /* WCTRuntimeBaseAccessor.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTRuntimeBaseAccessor.mm; path = objc/WCDB/interface/orm/accessor/WCTRuntimeBaseAccessor.mm; sourceTree = "<group>"; };
+		B86C1B08DCCEF5D44C608C4640680130 /* WCTRuntimeBaseAccessor.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTRuntimeBaseAccessor.mm; path = objc/WCDB/interface/orm/accessor/WCTRuntimeBaseAccessor.mm; sourceTree = "<group>"; };
 		B874FAC616392CF7279F1DA362076D77 /* MASCompositeConstraint.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MASCompositeConstraint.h; path = Masonry/MASCompositeConstraint.h; sourceTree = "<group>"; };
 		B89501A75389AB5988F48656E55EEF7B /* whereInt.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = whereInt.h; path = src/whereInt.h; sourceTree = "<group>"; };
 		B89CBE8AE63EE6E7180E5D1FDD054D3E /* YCViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = YCViewController.m; path = YCBase/Classes/YCViewController.m; sourceTree = "<group>"; };
-		B8D783AB96E047CFBC41F5F7A541E365 /* global.c */ = {isa = PBXFileReference; includeInIndex = 1; name = global.c; path = src/global.c; sourceTree = "<group>"; };
-		B8D88AC7BBDD37CF5AD53CF97F68074F /* WCTDatabase+Transaction.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTDatabase+Transaction.mm"; path = "objc/WCDB/interface/transaction/WCTDatabase+Transaction.mm"; sourceTree = "<group>"; };
+		B8D783AB96E047CFBC41F5F7A541E365 /* global.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = global.c; path = src/global.c; sourceTree = "<group>"; };
+		B8D88AC7BBDD37CF5AD53CF97F68074F /* WCTDatabase+Transaction.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTDatabase+Transaction.mm"; path = "objc/WCDB/interface/transaction/WCTDatabase+Transaction.mm"; sourceTree = "<group>"; };
 		B907F9383DE92B2679C57FE263A3BCA1 /* SDAnimatedImageView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDAnimatedImageView.h; path = SDWebImage/Core/SDAnimatedImageView.h; sourceTree = "<group>"; };
 		B9215642C43A229D20F5B7E16D2532B1 /* transaction.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = transaction.cpp; path = objc/WCDB/core/transaction.cpp; sourceTree = "<group>"; };
 		B98B57B3EC9F7F69636ADD38031DDF07 /* YCNavigationController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = YCNavigationController.m; path = YCBase/Classes/YCNavigationController.m; sourceTree = "<group>"; };
@@ -2345,18 +2346,18 @@
 		BA54223474A4A6913DEB58DF23C76BEE /* IQKeyboardManager.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = IQKeyboardManager.debug.xcconfig; sourceTree = "<group>"; };
 		BA716DF8C77C7743D93EA43FA89AA883 /* SDMemoryCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDMemoryCache.m; path = SDWebImage/Core/SDMemoryCache.m; sourceTree = "<group>"; };
 		BAA30D06319899C3E26A8ACE11E547F7 /* describable.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = describable.cpp; path = objc/WCDB/abstract/describable.cpp; sourceTree = "<group>"; };
-		BAACA1BF7AB3DD28402C4F9A7C2FD104 /* JSONModel */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = JSONModel; path = libJSONModel.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		BAACA1BF7AB3DD28402C4F9A7C2FD104 /* libJSONModel.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libJSONModel.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB0682A42A77654EC6600269ACA1EE1F /* ISO8601Serialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ISO8601Serialization.h; path = Sources/ISO8601Serialization.h; sourceTree = "<group>"; };
-		BB8CD125FE12D23CF94936E28BDBCF51 /* WCTCore.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTCore.mm; path = objc/WCDB/interface/core/WCTCore.mm; sourceTree = "<group>"; };
+		BB8CD125FE12D23CF94936E28BDBCF51 /* WCTCore.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTCore.mm; path = objc/WCDB/interface/core/WCTCore.mm; sourceTree = "<group>"; };
 		BBC281603C4F21365C9D4B4F257B56E9 /* LOTColorInterpolator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTColorInterpolator.h; path = "lottie-ios/Classes/RenderSystem/InterpolatorNodes/LOTColorInterpolator.h"; sourceTree = "<group>"; };
-		BC6FF894AB8BDD3B2330E4659C6A1E0B /* WCTSelect.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTSelect.mm; path = objc/WCDB/interface/chaincall/WCTSelect.mm; sourceTree = "<group>"; };
+		BC6FF894AB8BDD3B2330E4659C6A1E0B /* WCTSelect.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTSelect.mm; path = objc/WCDB/interface/chaincall/WCTSelect.mm; sourceTree = "<group>"; };
 		BC7DEDA45D0F16EE4DF0681FD1306207 /* JSONValueTransformer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = JSONValueTransformer.m; path = JSONModel/JSONModelTransformations/JSONValueTransformer.m; sourceTree = "<group>"; };
 		BC91B7499608F5DA2A5276325BB628EE /* spin.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = spin.hpp; path = objc/WCDB/util/spin.hpp; sourceTree = "<group>"; };
-		BCEA6DEB24063148DCFEED9DF7A11EC6 /* fault.c */ = {isa = PBXFileReference; includeInIndex = 1; name = fault.c; path = src/fault.c; sourceTree = "<group>"; };
+		BCEA6DEB24063148DCFEED9DF7A11EC6 /* fault.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fault.c; path = src/fault.c; sourceTree = "<group>"; };
 		BD4AF831EF6EB80C7B868845225E8413 /* spin.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = spin.cpp; path = objc/WCDB/util/spin.cpp; sourceTree = "<group>"; };
 		BD676514E2A35D1B5DAD660A0CBD8906 /* btreeInt.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = btreeInt.h; path = src/btreeInt.h; sourceTree = "<group>"; };
 		BDA0B73D4544F41C8001CA2CE56B14FA /* SRIOConsumer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SRIOConsumer.m; path = SocketRocket/Internal/IOConsumer/SRIOConsumer.m; sourceTree = "<group>"; };
-		BDA984A69B016A2AA60A0150A7739D11 /* fts3_write.c */ = {isa = PBXFileReference; includeInIndex = 1; name = fts3_write.c; path = ext/fts3/fts3_write.c; sourceTree = "<group>"; };
+		BDA984A69B016A2AA60A0150A7739D11 /* fts3_write.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fts3_write.c; path = ext/fts3/fts3_write.c; sourceTree = "<group>"; };
 		BE013002E0C66CE46FE0387D5BC9FDA7 /* YCGridView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = YCGridView.m; path = YCEasyTool/Classes/UI/Grid/YCGridView.m; sourceTree = "<group>"; };
 		BE63FF33B8D5DFBFDE1E11580217D4FE /* UIButton+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+AFNetworking.m"; path = "UIKit+AFNetworking/UIButton+AFNetworking.m"; sourceTree = "<group>"; };
 		BE66E6BD4D8FD1FF488F3F06D9863AA6 /* sqliteLimit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sqliteLimit.h; path = src/sqliteLimit.h; sourceTree = "<group>"; };
@@ -2379,7 +2380,7 @@
 		C1CF6F251025B0577CBD5D046B9DBFA9 /* IQUIScrollView+Additions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "IQUIScrollView+Additions.m"; path = "IQKeyboardManager/Categories/IQUIScrollView+Additions.m"; sourceTree = "<group>"; };
 		C1E65DDD624CBC544988928F3A386ACF /* LOTPolygonAnimator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTPolygonAnimator.h; path = "lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPolygonAnimator.h"; sourceTree = "<group>"; };
 		C231D0F4C845C301FA723D2C64D9F741 /* fts3_hash.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = fts3_hash.h; path = ext/fts3/fts3_hash.h; sourceTree = "<group>"; };
-		C261436D14052AE3C35F240BCD155CAC /* CocoaLumberjack */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = CocoaLumberjack; path = libCocoaLumberjack.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		C261436D14052AE3C35F240BCD155CAC /* libCocoaLumberjack.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCocoaLumberjack.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		C261CA9E991B58CB3FB75B6B1F5D0D13 /* UIView+SDExtension.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIView+SDExtension.h"; path = "SDCycleScrollView/Lib/SDCycleScrollView/UIView+SDExtension.h"; sourceTree = "<group>"; };
 		C272B707FA7EAF1D7ED7EAA905CCBF08 /* Pods-EulixSpaceTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-EulixSpaceTests-frameworks.sh"; sourceTree = "<group>"; };
 		C2CD193247506E82D9ADB47985D96B13 /* LOTShapeRepeater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTShapeRepeater.m; path = "lottie-ios/Classes/Models/LOTShapeRepeater.m"; sourceTree = "<group>"; };
@@ -2392,28 +2393,28 @@
 		C401324C5CB7874A28AC44F3D4FB5D5C /* SDImageCodersManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDImageCodersManager.h; path = SDWebImage/Core/SDImageCodersManager.h; sourceTree = "<group>"; };
 		C4261020F696AF95125B293F2A367140 /* UIColor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = UIColor.h; path = "lottie-ios/Classes/MacCompatibility/UIColor.h"; sourceTree = "<group>"; };
 		C46C9EBFE9CCEE19F388A41436A87AB8 /* SDImageCacheConfig.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDImageCacheConfig.h; path = SDWebImage/Core/SDImageCacheConfig.h; sourceTree = "<group>"; };
-		C4A846907997A2BCB62CA9F4FF77E1D1 /* vdbesort.c */ = {isa = PBXFileReference; includeInIndex = 1; name = vdbesort.c; path = src/vdbesort.c; sourceTree = "<group>"; };
-		C535B7E9FB55163570FD9970012F9AE5 /* opcodes.c */ = {isa = PBXFileReference; includeInIndex = 1; path = opcodes.c; sourceTree = "<group>"; };
+		C4A846907997A2BCB62CA9F4FF77E1D1 /* vdbesort.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = vdbesort.c; path = src/vdbesort.c; sourceTree = "<group>"; };
+		C535B7E9FB55163570FD9970012F9AE5 /* opcodes.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; path = opcodes.c; sourceTree = "<group>"; };
 		C5E52C99C2CC6D11594DD7BDF37516D7 /* GKWebImageProtocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GKWebImageProtocol.h; path = GKPhotoBrowser/Core/GKWebImageProtocol.h; sourceTree = "<group>"; };
-		C609D830504830935C99B20A54DEA16B /* WCTSequence.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTSequence.mm; path = objc/WCDB/interface/builtin/WCTSequence.mm; sourceTree = "<group>"; };
-		C68FF5BDA36E4B65EB8C734262EC660E /* sqliterk_pager.c */ = {isa = PBXFileReference; includeInIndex = 1; name = sqliterk_pager.c; path = repair/sqliterk_pager.c; sourceTree = "<group>"; };
+		C609D830504830935C99B20A54DEA16B /* WCTSequence.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTSequence.mm; path = objc/WCDB/interface/builtin/WCTSequence.mm; sourceTree = "<group>"; };
+		C68FF5BDA36E4B65EB8C734262EC660E /* sqliterk_pager.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = sqliterk_pager.c; path = repair/sqliterk_pager.c; sourceTree = "<group>"; };
 		C792848D6E87C50C66D0788FB3BAE01A /* sqliteInt.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sqliteInt.h; path = src/sqliteInt.h; sourceTree = "<group>"; };
 		C7AC06E30886BFA19EBC7B28B19B7DB9 /* sqliterk_util.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sqliterk_util.h; path = repair/sqliterk_util.h; sourceTree = "<group>"; };
 		C865E214AB8F9D1AD7E3951D0FDD898C /* Reachability-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Reachability-prefix.pch"; sourceTree = "<group>"; };
 		C8C0D1255D918A0242FAC9103D5F5EE0 /* SRIOConsumer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SRIOConsumer.h; path = SocketRocket/Internal/IOConsumer/SRIOConsumer.h; sourceTree = "<group>"; };
-		C8F826D0B234D07B2A0CF40A4D749566 /* WCTTokenizer+Apple.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTTokenizer+Apple.mm"; path = "objc/WCDB/interface/fts/WCTTokenizer+Apple.mm"; sourceTree = "<group>"; };
+		C8F826D0B234D07B2A0CF40A4D749566 /* WCTTokenizer+Apple.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTTokenizer+Apple.mm"; path = "objc/WCDB/interface/fts/WCTTokenizer+Apple.mm"; sourceTree = "<group>"; };
 		C90DD10FF4BF3727140AA944B97B6101 /* declare.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = declare.hpp; path = objc/WCDB/abstract/declare.hpp; sourceTree = "<group>"; };
 		C91863FE77DD885FCDB36CE72E938865 /* SDWebImageDownloaderDecryptor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDWebImageDownloaderDecryptor.m; path = SDWebImage/Core/SDWebImageDownloaderDecryptor.m; sourceTree = "<group>"; };
 		C9191347217EA3D3071CB34F534AAC2C /* order.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = order.hpp; path = objc/WCDB/abstract/order.hpp; sourceTree = "<group>"; };
-		C9547CC50544308C4064206A8AE61D89 /* mutex.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mutex.c; path = src/mutex.c; sourceTree = "<group>"; };
+		C9547CC50544308C4064206A8AE61D89 /* mutex.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mutex.c; path = src/mutex.c; sourceTree = "<group>"; };
 		C97F5BA52B147E13A4FD1C0FDCA16E58 /* NSValue+Compat.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+Compat.m"; path = "lottie-ios/Classes/MacCompatibility/NSValue+Compat.m"; sourceTree = "<group>"; };
 		C9BC6EE636C6EFD2144226ACDF5460D0 /* YCEasyTool-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "YCEasyTool-prefix.pch"; sourceTree = "<group>"; };
 		C9D86DB39211BAD951F41F0E1A14D9F0 /* UIImage+ExtendedCacheData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+ExtendedCacheData.h"; path = "SDWebImage/Core/UIImage+ExtendedCacheData.h"; sourceTree = "<group>"; };
 		CA486E84B07B69DD79F3F4813DDC14DD /* WCTInterface+Core.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTInterface+Core.h"; path = "objc/WCDB/interface/core/WCTInterface+Core.h"; sourceTree = "<group>"; };
 		CA608E3C51400AD357ABFC45303193AB /* ISO8601.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ISO8601.release.xcconfig; sourceTree = "<group>"; };
-		CAF0751214AFBE871D56A253826CE89D /* GKPhotoBrowser */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = GKPhotoBrowser; path = libGKPhotoBrowser.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		CAF0751214AFBE871D56A253826CE89D /* libGKPhotoBrowser.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libGKPhotoBrowser.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAF95F433EA7B26C7B9356E420526404 /* IQUIView+IQKeyboardToolbar.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "IQUIView+IQKeyboardToolbar.m"; path = "IQKeyboardManager/IQToolbar/IQUIView+IQKeyboardToolbar.m"; sourceTree = "<group>"; };
-		CAF99FCB6753C56C1DC48375AC2BAC36 /* auth.c */ = {isa = PBXFileReference; includeInIndex = 1; name = auth.c; path = src/auth.c; sourceTree = "<group>"; };
+		CAF99FCB6753C56C1DC48375AC2BAC36 /* auth.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = auth.c; path = src/auth.c; sourceTree = "<group>"; };
 		CC2911A3968E100E264A4F5D14371B83 /* YCTreeMenuView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCTreeMenuView.h; path = YCEasyTool/Classes/UI/TreeMenu/YCTreeMenuView.h; sourceTree = "<group>"; };
 		CC40EFBB7BF0CB1F60699FD602507823 /* SDImageCachesManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDImageCachesManager.m; path = SDWebImage/Core/SDImageCachesManager.m; sourceTree = "<group>"; };
 		CCDDFE7252F7BBDF51638355504F2983 /* LOTModels.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTModels.h; path = "lottie-ios/Classes/Models/LOTModels.h"; sourceTree = "<group>"; };
@@ -2422,11 +2423,11 @@
 		CDA433363635A30DA1413035A59331BD /* SRRunLoopThread.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SRRunLoopThread.m; path = SocketRocket/Internal/RunLoop/SRRunLoopThread.m; sourceTree = "<group>"; };
 		CE272EA5B1871930F3D4486E198D6B44 /* SSZipCommon.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SSZipCommon.h; path = SSZipArchive/SSZipCommon.h; sourceTree = "<group>"; };
 		CE27A860FA81B9F66C28EF4AB2B21572 /* GKPhotoView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GKPhotoView.h; path = GKPhotoBrowser/Core/GKPhotoView.h; sourceTree = "<group>"; };
-		CE632E8926A161261840C712B568204A /* mz_zip.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mz_zip.c; path = SSZipArchive/minizip/mz_zip.c; sourceTree = "<group>"; };
+		CE632E8926A161261840C712B568204A /* mz_zip.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mz_zip.c; path = SSZipArchive/minizip/mz_zip.c; sourceTree = "<group>"; };
 		CE94ED18CC1A6420C3CE0E5BB9BCF6E4 /* SDWebImageDownloaderOperation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDWebImageDownloaderOperation.h; path = SDWebImage/Core/SDWebImageDownloaderOperation.h; sourceTree = "<group>"; };
-		CF39C5934524E9EB42845D38C7C9079A /* bitvec.c */ = {isa = PBXFileReference; includeInIndex = 1; name = bitvec.c; path = src/bitvec.c; sourceTree = "<group>"; };
+		CF39C5934524E9EB42845D38C7C9079A /* bitvec.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = bitvec.c; path = src/bitvec.c; sourceTree = "<group>"; };
 		CF3D16FD61646679C9B8A32A22AF2D67 /* foreign_key.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = foreign_key.cpp; path = objc/WCDB/abstract/foreign_key.cpp; sourceTree = "<group>"; };
-		CF4671A98ADC3797921C0F695F6CAA05 /* tokenize.c */ = {isa = PBXFileReference; includeInIndex = 1; name = tokenize.c; path = src/tokenize.c; sourceTree = "<group>"; };
+		CF4671A98ADC3797921C0F695F6CAA05 /* tokenize.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = tokenize.c; path = src/tokenize.c; sourceTree = "<group>"; };
 		CFE299523D8259F56AC5E2818B2F3046 /* handle.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = handle.cpp; path = objc/WCDB/abstract/handle.cpp; sourceTree = "<group>"; };
 		D03AF062A4C8FB2EB34C3DE4CCE2CE0E /* GCDWebServer-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "GCDWebServer-dummy.m"; sourceTree = "<group>"; };
 		D05B3C65CBD04D8A91289DA70943F3DB /* WCTSelectBase+NoARC.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTSelectBase+NoARC.h"; path = "objc/WCDB/interface/chaincall/WCTSelectBase+NoARC.h"; sourceTree = "<group>"; };
@@ -2434,13 +2435,13 @@
 		D09EA14907BDCDFA69BC48297E7A5C7F /* IQUIView+Hierarchy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "IQUIView+Hierarchy.h"; path = "IQKeyboardManager/Categories/IQUIView+Hierarchy.h"; sourceTree = "<group>"; };
 		D0D0EED958783EBE5298AB5E2115D941 /* YCProperty.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCProperty.h; path = YCEasyTool/Classes/Property/YCProperty.h; sourceTree = "<group>"; };
 		D0FEC6CF680237A3FA50D9316AD6A5D7 /* SDImageHEICCoder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDImageHEICCoder.m; path = SDWebImage/Core/SDImageHEICCoder.m; sourceTree = "<group>"; };
-		D10731F4B53308A29178BF2D852DE684 /* vdbetrace.c */ = {isa = PBXFileReference; includeInIndex = 1; name = vdbetrace.c; path = src/vdbetrace.c; sourceTree = "<group>"; };
+		D10731F4B53308A29178BF2D852DE684 /* vdbetrace.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = vdbetrace.c; path = src/vdbetrace.c; sourceTree = "<group>"; };
 		D12D343032E2E309217F26484372E653 /* handle_recyclable.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = handle_recyclable.hpp; path = objc/WCDB/core/handle_recyclable.hpp; sourceTree = "<group>"; };
-		D15FC10C11721053D9DC7E517D470BF5 /* WCTInterface.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTInterface.mm; path = objc/WCDB/interface/declare/WCTInterface.mm; sourceTree = "<group>"; };
+		D15FC10C11721053D9DC7E517D470BF5 /* WCTInterface.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTInterface.mm; path = objc/WCDB/interface/declare/WCTInterface.mm; sourceTree = "<group>"; };
 		D16AA2CD134294577262513792C87DFA /* LOTComposition.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTComposition.h; path = "lottie-ios/Classes/PublicHeaders/LOTComposition.h"; sourceTree = "<group>"; };
 		D1E11DE2028948FB2382980B702821A6 /* LOTCompositionContainer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTCompositionContainer.m; path = "lottie-ios/Classes/AnimatableLayers/LOTCompositionContainer.m"; sourceTree = "<group>"; };
 		D20D7D2E939C351FA301D7CF3FB58C9C /* LOTAnimatedControl.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTAnimatedControl.m; path = "lottie-ios/Classes/Private/LOTAnimatedControl.m"; sourceTree = "<group>"; };
-		D2241FE10DEED48D646729036D75EBDC /* mz_strm_mem.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mz_strm_mem.c; path = SSZipArchive/minizip/mz_strm_mem.c; sourceTree = "<group>"; };
+		D2241FE10DEED48D646729036D75EBDC /* mz_strm_mem.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mz_strm_mem.c; path = SSZipArchive/minizip/mz_strm_mem.c; sourceTree = "<group>"; };
 		D23BB25AAAB76538E63026D8D3655A2F /* WCTCodingMacro.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTCodingMacro.h; path = objc/WCDB/interface/orm/macro/WCTCodingMacro.h; sourceTree = "<group>"; };
 		D28CD6CD8E2F92620A0A4211E7FAEC9D /* LOTAsset.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTAsset.h; path = "lottie-ios/Classes/Models/LOTAsset.h"; sourceTree = "<group>"; };
 		D2B32FCC21AE5B87847F7D729627D89F /* WCTSelectBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTSelectBase.h; path = objc/WCDB/interface/chaincall/WCTSelectBase.h; sourceTree = "<group>"; };
@@ -2452,18 +2453,18 @@
 		D343281C4BE1EFA99E5ABB5DBCEA0E9A /* sqliteicu.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sqliteicu.h; path = ext/icu/sqliteicu.h; sourceTree = "<group>"; };
 		D3517BA4431A05833CEA076F0B62A5E8 /* GKPhotoBrowser.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = GKPhotoBrowser.debug.xcconfig; sourceTree = "<group>"; };
 		D38B8C2038D315B88F5ECF83AD4FF8BA /* LOTCompositionContainer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTCompositionContainer.h; path = "lottie-ios/Classes/AnimatableLayers/LOTCompositionContainer.h"; sourceTree = "<group>"; };
-		D3A3DEDB427818970FAA5BD8524369D0 /* WCTBinding.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTBinding.mm; path = objc/WCDB/interface/orm/binding/WCTBinding.mm; sourceTree = "<group>"; };
+		D3A3DEDB427818970FAA5BD8524369D0 /* WCTBinding.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTBinding.mm; path = objc/WCDB/interface/orm/binding/WCTBinding.mm; sourceTree = "<group>"; };
 		D3BDFD3F4F2678355FB180B1DD8F4F71 /* NSURLRequest+SRWebSocket.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSURLRequest+SRWebSocket.h"; path = "SocketRocket/NSURLRequest+SRWebSocket.h"; sourceTree = "<group>"; };
 		D3C67E7810CE41248E0CCDFBE32C20D2 /* NSImage+Compatibility.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSImage+Compatibility.m"; path = "SDWebImage/Core/NSImage+Compatibility.m"; sourceTree = "<group>"; };
 		D43DBD5E0ADFA3F074D5F6069774B5D6 /* DDASLLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDASLLogger.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDASLLogger.h; sourceTree = "<group>"; };
 		D4431823EFE6E12FBA4E5E75A729897B /* WCDBOptimizedSQLCipher-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "WCDBOptimizedSQLCipher-prefix.pch"; sourceTree = "<group>"; };
-		D44A8FC7A78C00F5AAA023084B2DB2CD /* fts3_unicode2.c */ = {isa = PBXFileReference; includeInIndex = 1; name = fts3_unicode2.c; path = ext/fts3/fts3_unicode2.c; sourceTree = "<group>"; };
+		D44A8FC7A78C00F5AAA023084B2DB2CD /* fts3_unicode2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fts3_unicode2.c; path = ext/fts3/fts3_unicode2.c; sourceTree = "<group>"; };
 		D44C2ED14B05B58206AE9FF6C17697A1 /* Pods-EulixSpace.platform.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EulixSpace.platform.xcconfig"; sourceTree = "<group>"; };
 		D46501C60AA9F1B11DE8C13E4F58C275 /* YCCollectionView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = YCCollectionView.m; path = YCEasyTool/Classes/UI/CollectionView/YCCollectionView.m; sourceTree = "<group>"; };
 		D4A076C4001678725CCB7C4CE5B7A88D /* sqliterk_values.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sqliterk_values.h; path = repair/sqliterk_values.h; sourceTree = "<group>"; };
 		D4E267F475DC3702E927DBDF8D2DB135 /* YCBase.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = YCBase.debug.xcconfig; sourceTree = "<group>"; };
 		D4E51076CBFCF66EB18D0A25855FF40C /* column_def.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = column_def.cpp; path = objc/WCDB/abstract/column_def.cpp; sourceTree = "<group>"; };
-		D510100E4036DAE5025C31FAE07072F3 /* fkey.c */ = {isa = PBXFileReference; includeInIndex = 1; name = fkey.c; path = src/fkey.c; sourceTree = "<group>"; };
+		D510100E4036DAE5025C31FAE07072F3 /* fkey.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fkey.c; path = src/fkey.c; sourceTree = "<group>"; };
 		D527F76EF28305BA68550DD78E2666B5 /* JSONKeyMapper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = JSONKeyMapper.m; path = JSONModel/JSONModelTransformations/JSONKeyMapper.m; sourceTree = "<group>"; };
 		D5596979AE1022EABBD8C5C375E252BF /* LOTShapePath.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTShapePath.m; path = "lottie-ios/Classes/Models/LOTShapePath.m"; sourceTree = "<group>"; };
 		D566B03B556B6F56A458BBB4391070D9 /* SDImageCachesManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDImageCachesManager.h; path = SDWebImage/Core/SDImageCachesManager.h; sourceTree = "<group>"; };
@@ -2471,7 +2472,7 @@
 		D59AA0BD0401D306E15220722B2A5375 /* Pods-EulixSpaceTests.appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EulixSpaceTests.appstore.xcconfig"; sourceTree = "<group>"; };
 		D5AE5728F41DC208724869B3357A93FB /* GCDWebServerRequest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GCDWebServerRequest.h; path = GCDWebServer/Core/GCDWebServerRequest.h; sourceTree = "<group>"; };
 		D63CCEF96D1FC59EA295E221B6E9FFCA /* sqliterk_output.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = sqliterk_output.cpp; path = repair/sqliterk_output.cpp; sourceTree = "<group>"; };
-		D6890EA78E948EC52C85DDAFE26468EF /* fts5.c */ = {isa = PBXFileReference; includeInIndex = 1; path = fts5.c; sourceTree = "<group>"; };
+		D6890EA78E948EC52C85DDAFE26468EF /* fts5.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; path = fts5.c; sourceTree = "<group>"; };
 		D6A835D715A66AAAE5C71BC16AE7C6CF /* constraint_table.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = constraint_table.hpp; path = objc/WCDB/abstract/constraint_table.hpp; sourceTree = "<group>"; };
 		D6DD5065DFE674727F390FF9AD6DBB57 /* NSButton+WebCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSButton+WebCache.h"; path = "SDWebImage/Core/NSButton+WebCache.h"; sourceTree = "<group>"; };
 		D6E19EB88AB5B616533C0FC688A1A298 /* mz_os.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mz_os.h; path = SSZipArchive/minizip/mz_os.h; sourceTree = "<group>"; };
@@ -2479,7 +2480,7 @@
 		D75AC1E417646A697A5E9E660686D13D /* UIImage+GIF.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+GIF.m"; path = "SDWebImage/Core/UIImage+GIF.m"; sourceTree = "<group>"; };
 		D77D87D348DF41BF57966BB469E4A942 /* SRMutex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SRMutex.m; path = SocketRocket/Internal/Utilities/SRMutex.m; sourceTree = "<group>"; };
 		D79CB09B8E7F6E483E4B1B7AC2EBC4C1 /* LOTPointInterpolator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTPointInterpolator.m; path = "lottie-ios/Classes/RenderSystem/InterpolatorNodes/LOTPointInterpolator.m"; sourceTree = "<group>"; };
-		D7ABB9D514497B02A38A85CECF4A8DF8 /* random.c */ = {isa = PBXFileReference; includeInIndex = 1; name = random.c; path = src/random.c; sourceTree = "<group>"; };
+		D7ABB9D514497B02A38A85CECF4A8DF8 /* random.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = random.c; path = src/random.c; sourceTree = "<group>"; };
 		D7AE11EC4D18C0F40ACA4E4F8E603772 /* MJExtensionConst.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = MJExtensionConst.h; path = MJExtension/MJExtensionConst.h; sourceTree = "<group>"; };
 		D86009EF951DD362F4BCE3093BB35BAC /* WCDBOptimizedSQLCipher.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = WCDBOptimizedSQLCipher.release.xcconfig; sourceTree = "<group>"; };
 		D875C34EF958D7E41F279AC8C69A3781 /* WCTSelect.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTSelect.h; path = objc/WCDB/interface/chaincall/WCTSelect.h; sourceTree = "<group>"; };
@@ -2489,7 +2490,7 @@
 		D8F209531A62D8369C36E08696C83AC9 /* ISO8601.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ISO8601.h; path = Support/ISO8601.h; sourceTree = "<group>"; };
 		D9121939FD31D891CDE9B5ADC3201B31 /* YCMemeryCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCMemeryCache.h; path = YCEasyTool/Classes/Property/YCMemeryCache.h; sourceTree = "<group>"; };
 		D924EEF919F2D99CFC1F8BB10B586A62 /* IQKeyboardManager-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IQKeyboardManager-dummy.m"; sourceTree = "<group>"; };
-		D96183BEBE2281907EDE4CE1E5966AA1 /* fts3_unicode.c */ = {isa = PBXFileReference; includeInIndex = 1; name = fts3_unicode.c; path = ext/fts3/fts3_unicode.c; sourceTree = "<group>"; };
+		D96183BEBE2281907EDE4CE1E5966AA1 /* fts3_unicode.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fts3_unicode.c; path = ext/fts3/fts3_unicode.c; sourceTree = "<group>"; };
 		D98907DE70C971904C443C3DB9FCC41F /* statement_create_table.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = statement_create_table.hpp; path = objc/WCDB/abstract/statement_create_table.hpp; sourceTree = "<group>"; };
 		D99A79680DBB08C961632423CB0EC763 /* GKPhotoBrowserConfigure.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = GKPhotoBrowserConfigure.m; path = GKPhotoBrowser/Core/GKPhotoBrowserConfigure.m; sourceTree = "<group>"; };
 		D9E5C9BCA0B7DF18F24C2D25E848E5F6 /* LOTRenderNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTRenderNode.m; path = "lottie-ios/Classes/RenderSystem/LOTRenderNode.m"; sourceTree = "<group>"; };
@@ -2502,8 +2503,8 @@
 		DB43B0D6F19C1C0025EBBBDDA1B6E77C /* LOTBlockCallback.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTBlockCallback.h; path = "lottie-ios/Classes/PublicHeaders/LOTBlockCallback.h"; sourceTree = "<group>"; };
 		DB9D9B3E7CF0872900F45B4E648FA77B /* pragma.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = pragma.cpp; path = objc/WCDB/abstract/pragma.cpp; sourceTree = "<group>"; };
 		DBC2B030938E9161B6FE5B40563D4F18 /* WCTBaseAccessor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTBaseAccessor.h; path = objc/WCDB/interface/orm/accessor/WCTBaseAccessor.h; sourceTree = "<group>"; };
-		DC61E5681CAC2D490162A1A37DEC2BDF /* sqliterk_column.c */ = {isa = PBXFileReference; includeInIndex = 1; name = sqliterk_column.c; path = repair/sqliterk_column.c; sourceTree = "<group>"; };
-		DC8801400A499255B11380D2C3D88F24 /* WCTDelete.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTDelete.mm; path = objc/WCDB/interface/chaincall/WCTDelete.mm; sourceTree = "<group>"; };
+		DC61E5681CAC2D490162A1A37DEC2BDF /* sqliterk_column.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = sqliterk_column.c; path = repair/sqliterk_column.c; sourceTree = "<group>"; };
+		DC8801400A499255B11380D2C3D88F24 /* WCTDelete.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTDelete.mm; path = objc/WCDB/interface/chaincall/WCTDelete.mm; sourceTree = "<group>"; };
 		DC89F77351F500A420B99FA8CDC0466B /* AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworking.h; path = AFNetworking/AFNetworking.h; sourceTree = "<group>"; };
 		DCE40910CF6C60240D2E7E6A3017C68A /* WCTCppAccessor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTCppAccessor.h; path = objc/WCDB/interface/orm/accessor/WCTCppAccessor.h; sourceTree = "<group>"; };
 		DCE49F5D6A307342BBFA4DB54F4EE6CD /* TAPageControl.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = TAPageControl.m; path = SDCycleScrollView/Lib/SDCycleScrollView/PageControl/TAPageControl.m; sourceTree = "<group>"; };
@@ -2526,7 +2527,7 @@
 		E10517DAB8FCE7F33F92E29CD583DB4F /* DDLog+LOGV.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "DDLog+LOGV.h"; path = "Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog+LOGV.h"; sourceTree = "<group>"; };
 		E14647269D9A64E2A9BBC2ED1717E737 /* WCTRuntimeCppAccessor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTRuntimeCppAccessor.h; path = objc/WCDB/interface/orm/accessor/WCTRuntimeCppAccessor.h; sourceTree = "<group>"; };
 		E154B16B8BDCD7BAC61243B240CF4DDE /* GCDWebServerStreamedResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GCDWebServerStreamedResponse.h; path = GCDWebServer/Responses/GCDWebServerStreamedResponse.h; sourceTree = "<group>"; };
-		E19864C569A39A56AAD02F84807D6521 /* fts3_aux.c */ = {isa = PBXFileReference; includeInIndex = 1; name = fts3_aux.c; path = ext/fts3/fts3_aux.c; sourceTree = "<group>"; };
+		E19864C569A39A56AAD02F84807D6521 /* fts3_aux.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = fts3_aux.c; path = ext/fts3/fts3_aux.c; sourceTree = "<group>"; };
 		E1C213753A23226065F10C8A35B4DBC9 /* column_result.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = column_result.cpp; path = objc/WCDB/abstract/column_result.cpp; sourceTree = "<group>"; };
 		E1D0747B276DCD64E61B923DF1F1805B /* LOTGradientFillRender.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTGradientFillRender.m; path = "lottie-ios/Classes/RenderSystem/RenderNodes/LOTGradientFillRender.m"; sourceTree = "<group>"; };
 		E1E1E2DD2BE613C249248026121FF820 /* core_base.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = core_base.cpp; path = objc/WCDB/core/core_base.cpp; sourceTree = "<group>"; };
@@ -2534,13 +2535,13 @@
 		E232B562D9FA7D9ABBD9DEAD95990FA5 /* AFNetworking-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AFNetworking-dummy.m"; sourceTree = "<group>"; };
 		E2C298C37957AD8943B9A5DEAF4BA6E2 /* LOTArrayInterpolator.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTArrayInterpolator.h; path = "lottie-ios/Classes/RenderSystem/InterpolatorNodes/LOTArrayInterpolator.h"; sourceTree = "<group>"; };
 		E329957D0DD90BF1CE7C5E8F1898B490 /* LOTMaskContainer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTMaskContainer.m; path = "lottie-ios/Classes/AnimatableLayers/LOTMaskContainer.m"; sourceTree = "<group>"; };
-		E33A15FBCF22AAFA7201702430F3668D /* where.c */ = {isa = PBXFileReference; includeInIndex = 1; name = where.c; path = src/where.c; sourceTree = "<group>"; };
+		E33A15FBCF22AAFA7201702430F3668D /* where.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = where.c; path = src/where.c; sourceTree = "<group>"; };
 		E39294385DF0EC246781FE5FE392B842 /* rwlock.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = rwlock.cpp; path = objc/WCDB/util/rwlock.cpp; sourceTree = "<group>"; };
 		E3D6C94FD68C9C33897FD14A87FB7C84 /* SDWebImage.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SDWebImage.release.xcconfig; sourceTree = "<group>"; };
 		E41580078FE73E3FF72AC5BA0DCAC0A4 /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
 		E419E4146479B2A047CF628028FC72B0 /* LOTNumberInterpolator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTNumberInterpolator.m; path = "lottie-ios/Classes/RenderSystem/InterpolatorNodes/LOTNumberInterpolator.m"; sourceTree = "<group>"; };
 		E41B7CCF04236D736F41CBB4B1B012EB /* WCTTable+ChainCall.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTTable+ChainCall.h"; path = "objc/WCDB/interface/chaincall/WCTTable+ChainCall.h"; sourceTree = "<group>"; };
-		E460D5B0416D36F66EE8EC89E5D2FA0A /* YYModel */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = YYModel; path = libYYModel.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E460D5B0416D36F66EE8EC89E5D2FA0A /* libYYModel.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libYYModel.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E463CF6F6CB7942DB40CD4455720639A /* OpenSSL-Universal.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "OpenSSL-Universal.debug.xcconfig"; sourceTree = "<group>"; };
 		E4ACEBEB4F0EC3F3DE4E67F7B7E4E3F0 /* WCTTokenizer+WCDB.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTTokenizer+WCDB.h"; path = "objc/WCDB/interface/fts/WCTTokenizer+WCDB.h"; sourceTree = "<group>"; };
 		E4E5B82BF21BBC5BBBE7B4059DFB8BF8 /* DDASLLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDASLLogger.m; path = Sources/CocoaLumberjack/DDASLLogger.m; sourceTree = "<group>"; };
@@ -2562,21 +2563,21 @@
 		E8CA92F54248478436703761A826D48C /* LOTShapeRectangle.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTShapeRectangle.m; path = "lottie-ios/Classes/Models/LOTShapeRectangle.m"; sourceTree = "<group>"; };
 		E904F9179267435A846F708D0390092C /* database.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = database.hpp; path = objc/WCDB/core/database.hpp; sourceTree = "<group>"; };
 		E915C2573703ECEF118A49A09803703B /* SRMutex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SRMutex.h; path = SocketRocket/Internal/Utilities/SRMutex.h; sourceTree = "<group>"; };
-		E9216164016E5DAE5E8362FA322C4665 /* Pods-EulixSpaceTests */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "Pods-EulixSpaceTests"; path = "libPods-EulixSpaceTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		E97D43C46A45EE515A4DA3AF94398441 /* SVProgressHUD */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = SVProgressHUD; path = libSVProgressHUD.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E9216164016E5DAE5E8362FA322C4665 /* libPods-EulixSpaceTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EulixSpaceTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E97D43C46A45EE515A4DA3AF94398441 /* libSVProgressHUD.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSVProgressHUD.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9BFA0BEF2F689014CE60A849E647A03 /* WCTStatement+Compatible.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTStatement+Compatible.h"; path = "objc/WCDB/interface/compatible/WCTStatement+Compatible.h"; sourceTree = "<group>"; };
 		EA13D416AAF86F2E379DDFF1FFEE2C6A /* UIImage+MemoryCacheCost.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+MemoryCacheCost.h"; path = "SDWebImage/Core/UIImage+MemoryCacheCost.h"; sourceTree = "<group>"; };
-		EA15CAC5915C4279F24FD0E3A9415290 /* WCTMaster.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTMaster.mm; path = objc/WCDB/interface/builtin/WCTMaster.mm; sourceTree = "<group>"; };
+		EA15CAC5915C4279F24FD0E3A9415290 /* WCTMaster.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTMaster.mm; path = objc/WCDB/interface/builtin/WCTMaster.mm; sourceTree = "<group>"; };
 		EA78EBD5D4828A6E585334F8E26289F7 /* WCTTable+Convenient.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "WCTTable+Convenient.h"; path = "objc/WCDB/interface/convenient/WCTTable+Convenient.h"; sourceTree = "<group>"; };
 		EB21D07FEC7ED6D214CF5646338053A7 /* Pods-EulixSpaceTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EulixSpaceTests-dummy.m"; sourceTree = "<group>"; };
 		EB638222848BD1E41FCA9655C4176708 /* SDImageCoder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDImageCoder.m; path = SDWebImage/Core/SDImageCoder.m; sourceTree = "<group>"; };
-		EB6F621A4031E7B38E3ADADA20ECCE10 /* callback.c */ = {isa = PBXFileReference; includeInIndex = 1; name = callback.c; path = src/callback.c; sourceTree = "<group>"; };
+		EB6F621A4031E7B38E3ADADA20ECCE10 /* callback.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = callback.c; path = src/callback.c; sourceTree = "<group>"; };
 		EC0F09CAF4F855CD4E82A277AE33EF33 /* GKPhotoManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = GKPhotoManager.m; path = GKPhotoBrowser/Core/GKPhotoManager.m; sourceTree = "<group>"; };
 		EC153368E7CFF03B50F79EE50AB00EAF /* SDWebImageCompat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDWebImageCompat.h; path = SDWebImage/Core/SDWebImageCompat.h; sourceTree = "<group>"; };
 		EC1F808FDB597AB7BCD9B372D85A8037 /* statement_reindex.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement_reindex.cpp; path = objc/WCDB/abstract/statement_reindex.cpp; sourceTree = "<group>"; };
 		EC47246A152369C88509435E6642F907 /* ZipArchive.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ZipArchive.h; path = SSZipArchive/ZipArchive.h; sourceTree = "<group>"; };
 		EC72C6E2273BC0E7B0A4C450D74C523C /* UIImage+ExtendedCacheData.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+ExtendedCacheData.m"; path = "SDWebImage/Core/UIImage+ExtendedCacheData.m"; sourceTree = "<group>"; };
-		EC7F9F5D5CAE6D83B00BEEC8FE712700 /* os.c */ = {isa = PBXFileReference; includeInIndex = 1; name = os.c; path = src/os.c; sourceTree = "<group>"; };
+		EC7F9F5D5CAE6D83B00BEEC8FE712700 /* os.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = os.c; path = src/os.c; sourceTree = "<group>"; };
 		ECAEC2878449C566BB24D0FD22C5F4B8 /* WCDB-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "WCDB-prefix.pch"; sourceTree = "<group>"; };
 		ECC07F19E89FF5A5B09BBAFFF78FF5AE /* LOTShapeTransform.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTShapeTransform.m; path = "lottie-ios/Classes/Models/LOTShapeTransform.m"; sourceTree = "<group>"; };
 		ECD120FBFE15184A921B0C1B7CD62274 /* SDWebImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDWebImage.h; path = WebImage/SDWebImage.h; sourceTree = "<group>"; };
@@ -2585,9 +2586,9 @@
 		ED839D578AEC5F8230DAEAB3D5B9BA23 /* SDImageAWebPCoder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDImageAWebPCoder.m; path = SDWebImage/Core/SDImageAWebPCoder.m; sourceTree = "<group>"; };
 		ED9FCB41B526F710274EADC3FFB37D48 /* SDCycleScrollView-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SDCycleScrollView-prefix.pch"; sourceTree = "<group>"; };
 		EE170536DD12C7E723195AFA8623FF16 /* IQBarButtonItem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IQBarButtonItem.h; path = IQKeyboardManager/IQToolbar/IQBarButtonItem.h; sourceTree = "<group>"; };
-		EE40E7BF833A78EA9362AA7E5C3DAC25 /* sqliterk_api.c */ = {isa = PBXFileReference; includeInIndex = 1; name = sqliterk_api.c; path = repair/sqliterk_api.c; sourceTree = "<group>"; };
+		EE40E7BF833A78EA9362AA7E5C3DAC25 /* sqliterk_api.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = sqliterk_api.c; path = repair/sqliterk_api.c; sourceTree = "<group>"; };
 		EE511EB6C839A21C2A9FD0E98A39FF45 /* WCTInsert.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTInsert.h; path = objc/WCDB/interface/chaincall/WCTInsert.h; sourceTree = "<group>"; };
-		EE600C6FB30A74CA49E21D6FFC4C82ED /* vdbeblob.c */ = {isa = PBXFileReference; includeInIndex = 1; name = vdbeblob.c; path = src/vdbeblob.c; sourceTree = "<group>"; };
+		EE600C6FB30A74CA49E21D6FFC4C82ED /* vdbeblob.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = vdbeblob.c; path = src/vdbeblob.c; sourceTree = "<group>"; };
 		EE669645367ACEA4E3FA59FBA8F1419A /* YCGridViewCell.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCGridViewCell.h; path = YCEasyTool/Classes/UI/Grid/YCGridViewCell.h; sourceTree = "<group>"; };
 		EE9CF7A9ECFDF76D4A3A9F0FD2469DD5 /* LOTTrimPathNode.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTTrimPathNode.m; path = "lottie-ios/Classes/RenderSystem/ManipulatorNodes/LOTTrimPathNode.m"; sourceTree = "<group>"; };
 		EEBF53B3C772B1FE3808B1FDDA0CFFDC /* WCDB-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "WCDB-dummy.m"; sourceTree = "<group>"; };
@@ -2595,9 +2596,9 @@
 		EF17082ACFB11DFEEB79C92DE147FE65 /* IQUITextFieldView+Additions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "IQUITextFieldView+Additions.m"; path = "IQKeyboardManager/Categories/IQUITextFieldView+Additions.m"; sourceTree = "<group>"; };
 		EF50ED7A1CF4E075C0AAE3CEDD554B76 /* LOTPathAnimator.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = LOTPathAnimator.m; path = "lottie-ios/Classes/RenderSystem/AnimatorNodes/LOTPathAnimator.m"; sourceTree = "<group>"; };
 		EF96AA1B0BDC14C58B8E05672691C0E1 /* WCDB.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = WCDB.release.xcconfig; sourceTree = "<group>"; };
-		EF96F4A79B803DABE921F427E124F629 /* WCTInterface+ChainCall.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTInterface+ChainCall.mm"; path = "objc/WCDB/interface/chaincall/WCTInterface+ChainCall.mm"; sourceTree = "<group>"; };
-		F03377F0BDCB99F850DDA79DABB1AE34 /* os_wcdb.c */ = {isa = PBXFileReference; includeInIndex = 1; name = os_wcdb.c; path = src/os_wcdb.c; sourceTree = "<group>"; };
-		F05EEC1F28AE4C662823A19EBE099EE9 /* mz_strm_split.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mz_strm_split.c; path = SSZipArchive/minizip/mz_strm_split.c; sourceTree = "<group>"; };
+		EF96F4A79B803DABE921F427E124F629 /* WCTInterface+ChainCall.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTInterface+ChainCall.mm"; path = "objc/WCDB/interface/chaincall/WCTInterface+ChainCall.mm"; sourceTree = "<group>"; };
+		F03377F0BDCB99F850DDA79DABB1AE34 /* os_wcdb.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = os_wcdb.c; path = src/os_wcdb.c; sourceTree = "<group>"; };
+		F05EEC1F28AE4C662823A19EBE099EE9 /* mz_strm_split.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mz_strm_split.c; path = SSZipArchive/minizip/mz_strm_split.c; sourceTree = "<group>"; };
 		F0D0B1C4D5D200A1BAB60BDDFD862862 /* mz.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mz.h; path = SSZipArchive/minizip/mz.h; sourceTree = "<group>"; };
 		F0D34E025F3E8932475203C54DBBE666 /* CocoaLumberjack-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CocoaLumberjack-prefix.pch"; sourceTree = "<group>"; };
 		F0E97333772C6FF9D15A164ACCA0ACF9 /* GKPanGestureRecognizer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GKPanGestureRecognizer.h; path = GKPhotoBrowser/Core/GKPanGestureRecognizer.h; sourceTree = "<group>"; };
@@ -2610,17 +2611,17 @@
 		F1DF63959682A1C68D2E4342B3EEAA04 /* YCCollectionViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = YCCollectionViewController.m; path = YCBase/Classes/YCCollectionViewController.m; sourceTree = "<group>"; };
 		F24F67849519C258848F63904C636CF8 /* SRRunLoopThread.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SRRunLoopThread.h; path = SocketRocket/Internal/RunLoop/SRRunLoopThread.h; sourceTree = "<group>"; };
 		F25A28509414EB573D00F6E2536B8D24 /* module_argument.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = module_argument.cpp; path = objc/WCDB/abstract/module_argument.cpp; sourceTree = "<group>"; };
-		F2710788070B90071961669CCFAC08B7 /* Pods-EulixSpace */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "Pods-EulixSpace"; path = "libPods-EulixSpace.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F2710788070B90071961669CCFAC08B7 /* libPods-EulixSpace.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EulixSpace.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F2777A039A5375B0C6CA30301E5201B6 /* AFURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLResponseSerialization.h; path = AFNetworking/AFURLResponseSerialization.h; sourceTree = "<group>"; };
 		F28F420C93CE1FF828EFE436D89D7C7C /* SAMKeychain.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SAMKeychain.m; path = Sources/SAMKeychain.m; sourceTree = "<group>"; };
 		F29329CCF5A527CD9C308465BFD29FF4 /* database_file.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = database_file.cpp; path = objc/WCDB/core/database_file.cpp; sourceTree = "<group>"; };
-		F2A5664E8E06FF4A9551D990EC47B1F5 /* mutex_noop.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mutex_noop.c; path = src/mutex_noop.c; sourceTree = "<group>"; };
+		F2A5664E8E06FF4A9551D990EC47B1F5 /* mutex_noop.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mutex_noop.c; path = src/mutex_noop.c; sourceTree = "<group>"; };
 		F2B7697BAC7CA99FC7702296DB2E5037 /* GCDWebServerConnection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GCDWebServerConnection.h; path = GCDWebServer/Core/GCDWebServerConnection.h; sourceTree = "<group>"; };
-		F2D6B6B16CC735A8F8271AAC3B397C13 /* WCTSelectBase+NoARC.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = "WCTSelectBase+NoARC.mm"; path = "objc/WCDB/interface/chaincall/WCTSelectBase+NoARC.mm"; sourceTree = "<group>"; };
+		F2D6B6B16CC735A8F8271AAC3B397C13 /* WCTSelectBase+NoARC.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = "WCTSelectBase+NoARC.mm"; path = "objc/WCDB/interface/chaincall/WCTSelectBase+NoARC.mm"; sourceTree = "<group>"; };
 		F2EE21165838037BB117A46FFD0E55DF /* IQUIView+Hierarchy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "IQUIView+Hierarchy.m"; path = "IQKeyboardManager/Categories/IQUIView+Hierarchy.m"; sourceTree = "<group>"; };
 		F321C1308DF7D1FBDC3B8B4A5A274865 /* WCTColumnBinding.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTColumnBinding.h; path = objc/WCDB/interface/orm/binding/WCTColumnBinding.h; sourceTree = "<group>"; };
 		F3306DF0A7EC75B7A6F9D64754461F25 /* JSONModel-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "JSONModel-dummy.m"; sourceTree = "<group>"; };
-		F341C3F03F6FD21A5B4F5F2E7E869DCE /* memjournal.c */ = {isa = PBXFileReference; includeInIndex = 1; name = memjournal.c; path = src/memjournal.c; sourceTree = "<group>"; };
+		F341C3F03F6FD21A5B4F5F2E7E869DCE /* memjournal.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = memjournal.c; path = src/memjournal.c; sourceTree = "<group>"; };
 		F34CA01DF0013AAC9F803197F0503A69 /* WCTExpr.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTExpr.h; path = objc/WCDB/interface/orm/coding/WCTExpr.h; sourceTree = "<group>"; };
 		F34FD84FAA1AB66A44C38216CD6973CB /* SDImageGIFCoder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDImageGIFCoder.m; path = SDWebImage/Core/SDImageGIFCoder.m; sourceTree = "<group>"; };
 		F3643E4B02FFFB938D50FB3165974ABD /* SRURLUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SRURLUtilities.h; path = SocketRocket/Internal/Utilities/SRURLUtilities.h; sourceTree = "<group>"; };
@@ -2643,9 +2644,9 @@
 		F54B6A630BEFBB679AD386CCF63506FD /* UIActivityIndicatorView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActivityIndicatorView+AFNetworking.h"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h"; sourceTree = "<group>"; };
 		F56BB1894F4A3DA8A35220E7DAB80D8F /* DDOSLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDOSLogger.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDOSLogger.h; sourceTree = "<group>"; };
 		F57EBC28ECA06FB378CAA6394050C1CD /* SDImageLoader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDImageLoader.h; path = SDWebImage/Core/SDImageLoader.h; sourceTree = "<group>"; };
-		F58B55BC331986760EB3E58F79FEBA79 /* expr.c */ = {isa = PBXFileReference; includeInIndex = 1; name = expr.c; path = src/expr.c; sourceTree = "<group>"; };
+		F58B55BC331986760EB3E58F79FEBA79 /* expr.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = expr.c; path = src/expr.c; sourceTree = "<group>"; };
 		F595166F031677BB2369483B36282CC6 /* SDAnimatedImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDAnimatedImage.h; path = SDWebImage/Core/SDAnimatedImage.h; sourceTree = "<group>"; };
-		F5996CD59696051B73F70CE6BEC20421 /* vacuum.c */ = {isa = PBXFileReference; includeInIndex = 1; name = vacuum.c; path = src/vacuum.c; sourceTree = "<group>"; };
+		F5996CD59696051B73F70CE6BEC20421 /* vacuum.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = vacuum.c; path = src/vacuum.c; sourceTree = "<group>"; };
 		F63B5BC00B486737B0F4B0B2B9B68E70 /* sqlcipher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = sqlcipher.h; path = src/sqlcipher.h; sourceTree = "<group>"; };
 		F64EAD525996177552A7229A780A00B7 /* SVRadialGradientLayer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SVRadialGradientLayer.m; path = SVProgressHUD/SVRadialGradientLayer.m; sourceTree = "<group>"; };
 		F697F9C52CD18619ED93FBF98B5AAADD /* UIImage+Transform.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Transform.m"; path = "SDWebImage/Core/UIImage+Transform.m"; sourceTree = "<group>"; };
@@ -2656,7 +2657,7 @@
 		F8251E1CC760D1D1FF5FE55C929C5613 /* SRHash.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SRHash.h; path = SocketRocket/Internal/Utilities/SRHash.h; sourceTree = "<group>"; };
 		F85B8DF23E7D75D37B6EF989F63668C7 /* YYDiskCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = YYDiskCache.m; path = YYCache/YYDiskCache.m; sourceTree = "<group>"; };
 		F867F9255413E59A0CC73673CA9834C6 /* DDLoggerNames.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDLoggerNames.m; path = Sources/CocoaLumberjack/DDLoggerNames.m; sourceTree = "<group>"; };
-		F87956059979C2524E4344E3505635D7 /* whereexpr.c */ = {isa = PBXFileReference; includeInIndex = 1; name = whereexpr.c; path = src/whereexpr.c; sourceTree = "<group>"; };
+		F87956059979C2524E4344E3505635D7 /* whereexpr.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = whereexpr.c; path = src/whereexpr.c; sourceTree = "<group>"; };
 		F8CB084A7DA59B10A66B66F4BA57E5DC /* thread_local.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = thread_local.hpp; path = objc/WCDB/util/thread_local.hpp; sourceTree = "<group>"; };
 		F91E6536A139E7CC68F4AAC537212CB1 /* SDAnimatedImageView+WebCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "SDAnimatedImageView+WebCache.h"; path = "SDWebImage/Core/SDAnimatedImageView+WebCache.h"; sourceTree = "<group>"; };
 		F98EAF21CFB6B2734DD01F6FFD1E762D /* YYCache.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = YYCache.release.xcconfig; sourceTree = "<group>"; };
@@ -2665,10 +2666,10 @@
 		FA17FAF749D7E2FBE43A6ACF54F59C4B /* DDLoggerNames.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDLoggerNames.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDLoggerNames.h; sourceTree = "<group>"; };
 		FA28F6DDB8BC20ADE4D04DD70F72C6B8 /* YCViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCViewController.h; path = YCBase/Classes/YCViewController.h; sourceTree = "<group>"; };
 		FA331296F8497897AD25177D20DBB50A /* IQKeyboardManagerConstantsInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IQKeyboardManagerConstantsInternal.h; path = IQKeyboardManager/Constants/IQKeyboardManagerConstantsInternal.h; sourceTree = "<group>"; };
-		FAA5F2D71B90788C908800A94534AA92 /* FLAnimatedImage */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = FLAnimatedImage; path = libFLAnimatedImage.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		FAA5F2D71B90788C908800A94534AA92 /* libFLAnimatedImage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libFLAnimatedImage.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB0B1BAAA569AC1A489C0DFF62C78ADF /* LOTPlatformCompat.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTPlatformCompat.h; path = "lottie-ios/Classes/MacCompatibility/LOTPlatformCompat.h"; sourceTree = "<group>"; };
 		FB2E194EC8F0971CC02FA53ADA8E3FFF /* SDWebImageDownloaderConfig.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SDWebImageDownloaderConfig.h; path = SDWebImage/Core/SDWebImageDownloaderConfig.h; sourceTree = "<group>"; };
-		FBB1FB999802CC111112A4F91BE625D2 /* WCTStatement.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTStatement.mm; path = objc/WCDB/interface/core/WCTStatement.mm; sourceTree = "<group>"; };
+		FBB1FB999802CC111112A4F91BE625D2 /* WCTStatement.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTStatement.mm; path = objc/WCDB/interface/core/WCTStatement.mm; sourceTree = "<group>"; };
 		FBB4E7A8D96D7FCA7476A5CBB2943CAE /* NSObject+MJKeyValue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+MJKeyValue.h"; path = "MJExtension/NSObject+MJKeyValue.h"; sourceTree = "<group>"; };
 		FBF86027FF35632F830D07579360EFE4 /* UIImage+GIF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+GIF.h"; path = "SDWebImage/Core/UIImage+GIF.h"; sourceTree = "<group>"; };
 		FBFA012CAE650E8E7DAE23BEAD024827 /* YCSegmentedControl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = YCSegmentedControl.h; path = YCEasyTool/Classes/UI/Segment/YCSegmentedControl.h; sourceTree = "<group>"; };
@@ -2679,9 +2680,9 @@
 		FC2247500407F16151FFC1E0E0CF0210 /* lottie-ios-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "lottie-ios-dummy.m"; sourceTree = "<group>"; };
 		FC36EED0F242A3C8C41AF26281AB6358 /* subquery.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; name = subquery.hpp; path = objc/WCDB/abstract/subquery.hpp; sourceTree = "<group>"; };
 		FCA39A31555FC0F79273FD6E0554AD80 /* FLAnimatedImage-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FLAnimatedImage-prefix.pch"; sourceTree = "<group>"; };
-		FCD38746F5F8E4879241AB2AD48505AF /* WCTError.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTError.mm; path = objc/WCDB/interface/statictics/WCTError.mm; sourceTree = "<group>"; };
+		FCD38746F5F8E4879241AB2AD48505AF /* WCTError.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTError.mm; path = objc/WCDB/interface/statictics/WCTError.mm; sourceTree = "<group>"; };
 		FCE6A1570C3BD5C5F404131A21E35F7E /* LOTValueDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LOTValueDelegate.h; path = "lottie-ios/Classes/PublicHeaders/LOTValueDelegate.h"; sourceTree = "<group>"; };
-		FCF3AD7F96C226E1EDFBDE7817901969 /* mz_strm_pkcrypt.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mz_strm_pkcrypt.c; path = SSZipArchive/minizip/mz_strm_pkcrypt.c; sourceTree = "<group>"; };
+		FCF3AD7F96C226E1EDFBDE7817901969 /* mz_strm_pkcrypt.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mz_strm_pkcrypt.c; path = SSZipArchive/minizip/mz_strm_pkcrypt.c; sourceTree = "<group>"; };
 		FD3BCE3C14A3DF7F7468822A796E768A /* SDWebImageDownloaderOperation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SDWebImageDownloaderOperation.m; path = SDWebImage/Core/SDWebImageDownloaderOperation.m; sourceTree = "<group>"; };
 		FD51488A37CC8F9955E5E3C0F75DECFA /* DDTTYLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDTTYLogger.h; path = Sources/CocoaLumberjack/include/CocoaLumberjack/DDTTYLogger.h; sourceTree = "<group>"; };
 		FD65BA0ED527F129F7A18308F4624CF4 /* GKPhotoBrowser-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "GKPhotoBrowser-prefix.pch"; sourceTree = "<group>"; };
@@ -2692,7 +2693,7 @@
 		FE985CF1415834F844AC7B160FF4C94C /* statement.cpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = statement.cpp; path = objc/WCDB/abstract/statement.cpp; sourceTree = "<group>"; };
 		FEA1FEF918FD57CDA9D57C88F61CCF2A /* GCDWebServerConnection.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = GCDWebServerConnection.m; path = GCDWebServer/Core/GCDWebServerConnection.m; sourceTree = "<group>"; };
 		FEABD5B37F21E9B99BAF06EDCCC6ED5C /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
-		FF06F2FDC61973432F2C570A592F197A /* WCTValue.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = WCTValue.mm; path = objc/WCDB/interface/core/WCTValue.mm; sourceTree = "<group>"; };
+		FF06F2FDC61973432F2C570A592F197A /* WCTValue.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = WCTValue.mm; path = objc/WCDB/interface/core/WCTValue.mm; sourceTree = "<group>"; };
 		FF7B252BE0589742B35C4BFABAEA5EA0 /* YYModel-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "YYModel-dummy.m"; sourceTree = "<group>"; };
 		FFA29F9CB63934BCEB7E9B7E3F8EA2E5 /* WCTTransaction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WCTTransaction.h; path = objc/WCDB/interface/transaction/WCTTransaction.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -2911,7 +2912,6 @@
 				248411494793D0E0517F74D9B8C0F5E1 /* Resources */,
 				D92AB015945D471324D34F55C2BB0E9C /* Support Files */,
 			);
-			name = SVProgressHUD;
 			path = SVProgressHUD;
 			sourceTree = "<group>";
 		};
@@ -2930,7 +2930,6 @@
 				B89CBE8AE63EE6E7180E5D1FDD054D3E /* YCViewController.m */,
 				4645AC8E682A400D23C1EE823050C43C /* Support Files */,
 			);
-			name = YCBase;
 			path = YCBase;
 			sourceTree = "<group>";
 		};
@@ -3014,7 +3013,6 @@
 				A83E5B959FB74B310D58207A4151DEBF /* Core */,
 				B0C49383B4CBD43D08DECA817CECDE03 /* Support Files */,
 			);
-			name = CocoaLumberjack;
 			path = CocoaLumberjack;
 			sourceTree = "<group>";
 		};
@@ -3053,7 +3051,6 @@
 				BC8881AF2FE2BC2262E2EA80D1045AB0 /* Support Files */,
 				03CB426D54D041DE56CDA11F9EBEB72F /* UI */,
 			);
-			name = YCEasyTool;
 			path = YCEasyTool;
 			sourceTree = "<group>";
 		};
@@ -3103,7 +3100,6 @@
 				401F4D91959AFBB7FD5A060AF9D28C88 /* SRWebSocket.m */,
 				CFA672EA598E74170088DA5CD299BB61 /* Support Files */,
 			);
-			name = SocketRocket;
 			path = SocketRocket;
 			sourceTree = "<group>";
 		};
@@ -3258,7 +3254,6 @@
 				B89501A75389AB5988F48656E55EEF7B /* whereInt.h */,
 				5818B4FB5931BA68C3A8CC9159A021B3 /* Support Files */,
 			);
-			name = WCDBOptimizedSQLCipher;
 			path = WCDBOptimizedSQLCipher;
 			sourceTree = "<group>";
 		};
@@ -3321,7 +3316,6 @@
 				924698071E62465B2738FAD138DDBDA8 /* Frameworks */,
 				D10E730494CA2F8EFCC72862631AF47F /* Support Files */,
 			);
-			name = "OpenSSL-Universal";
 			path = "OpenSSL-Universal";
 			sourceTree = "<group>";
 		};
@@ -3404,7 +3398,6 @@
 				39294F991037CFC45EAFB8E29ACF882D /* YYModel.h */,
 				08F656FD8D7094FC18DB85CBF87F3F05 /* Support Files */,
 			);
-			name = YYModel;
 			path = YYModel;
 			sourceTree = "<group>";
 		};
@@ -3466,7 +3459,6 @@
 				D4A076C4001678725CCB7C4CE5B7A88D /* sqliterk_values.h */,
 				5A037A20582F329D0E08B394A291FEAC /* Support Files */,
 			);
-			name = SQLiteRepairKit;
 			path = SQLiteRepairKit;
 			sourceTree = "<group>";
 		};
@@ -3604,7 +3596,6 @@
 				33CAC3BC97E8A0D92C3BC92F27C1F110 /* UIColor+Expanded.m */,
 				91A1CA0626D55836BA18CD13B1B15ADA /* Support Files */,
 			);
-			name = "lottie-ios";
 			path = "lottie-ios";
 			sourceTree = "<group>";
 		};
@@ -3877,7 +3868,6 @@
 				BC7DEDA45D0F16EE4DF0681FD1306207 /* JSONValueTransformer.m */,
 				07C6185B0A0569F1CBA83061E8F37336 /* Support Files */,
 			);
-			name = JSONModel;
 			path = JSONModel;
 			sourceTree = "<group>";
 		};
@@ -3891,7 +3881,6 @@
 				12F9D1CA3FEB14AC22BA653217CEDFF0 /* NSDate+ISO8601.m */,
 				29B8E7139518B5376D513173EE07F410 /* Support Files */,
 			);
-			name = ISO8601;
 			path = ISO8601;
 			sourceTree = "<group>";
 		};
@@ -4196,7 +4185,6 @@
 				FF06F2FDC61973432F2C570A592F197A /* WCTValue.mm */,
 				6ED1C3750F0940F73371C5BE220F7682 /* Support Files */,
 			);
-			name = WCDB;
 			path = WCDB;
 			sourceTree = "<group>";
 		};
@@ -4206,7 +4194,6 @@
 				6924E6C70716ACDACCF0F9F73A56265F /* Core */,
 				DCF56A4EE17E23BF1A10EC3339371DC5 /* Support Files */,
 			);
-			name = SDWebImage;
 			path = SDWebImage;
 			sourceTree = "<group>";
 		};
@@ -4228,7 +4215,6 @@
 				F9D5118AB35630565AA8FAD7044A864C /* FLAnimatedImageView.m */,
 				18D6E9865CE585EB0B2C41FF4F17356D /* Support Files */,
 			);
-			name = FLAnimatedImage;
 			path = FLAnimatedImage;
 			sourceTree = "<group>";
 		};
@@ -4280,7 +4266,6 @@
 				B8399A00C325BF964001DA9B05100EF6 /* SD */,
 				29CE8FE01E449BF111AC15C80AC2EB81 /* Support Files */,
 			);
-			name = GKPhotoBrowser;
 			path = GKPhotoBrowser;
 			sourceTree = "<group>";
 		};
@@ -4290,7 +4275,6 @@
 				6FAC28FEDC8ED8785B5290139E8C9304 /* Core */,
 				5409FC6ECD0C44ED6BF4545BFDAC50E9 /* Support Files */,
 			);
-			name = GCDWebServer;
 			path = GCDWebServer;
 			sourceTree = "<group>";
 		};
@@ -4350,7 +4334,6 @@
 				B5E74D16144D0295DE5686B84C0EF8B8 /* NSString+MJExtension.m */,
 				B5D9DC01BA5DAE3BA023B3D7E511628E /* Support Files */,
 			);
-			name = MJExtension;
 			path = MJExtension;
 			sourceTree = "<group>";
 		};
@@ -4441,7 +4424,6 @@
 				EC47246A152369C88509435E6642F907 /* ZipArchive.h */,
 				6B0ADFABAEB6A55FEBD0C84F87F89203 /* Support Files */,
 			);
-			name = SSZipArchive;
 			path = SSZipArchive;
 			sourceTree = "<group>";
 		};
@@ -4511,7 +4493,6 @@
 				A041EA365B512B82F689AC9F0435E241 /* IQUIViewController+Additions.m */,
 				7B5D56ADB909EEB78551E67631AF8720 /* Support Files */,
 			);
-			name = IQKeyboardManager;
 			path = IQKeyboardManager;
 			sourceTree = "<group>";
 		};
@@ -4534,7 +4515,6 @@
 				2839F8D782DD4E117AED5624D3296D46 /* Reachability.m */,
 				C986DCBFBECEB9B30FBE572707CDC0B1 /* Support Files */,
 			);
-			name = Reachability;
 			path = Reachability;
 			sourceTree = "<group>";
 		};
@@ -4613,7 +4593,6 @@
 				C8EA6ED2166D6809DC785E6E6D01B815 /* Resources */,
 				6A4C0805E688D565CAA71FAA2BC960A9 /* Support Files */,
 			);
-			name = SAMKeychain;
 			path = SAMKeychain;
 			sourceTree = "<group>";
 		};
@@ -4704,41 +4683,40 @@
 				38560C60055F85F11D9F82FDFB7B61C5 /* FileHash.m */,
 				7BD10BEC77EE8B25B36BC488E0E3D697 /* Support Files */,
 			);
-			name = FileMD5Hash;
 			path = FileMD5Hash;
 			sourceTree = "<group>";
 		};
 		E03F3B6BD5939B1CECE68C422122C920 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				A4FA15D44DF6BAC7550EDEED10862AA3 /* AFNetworking */,
-				C261436D14052AE3C35F240BCD155CAC /* CocoaLumberjack */,
-				03EBC375BDAF9B3A8C8050FCDD486C29 /* FileMD5Hash */,
-				FAA5F2D71B90788C908800A94534AA92 /* FLAnimatedImage */,
-				B68C1052A3B51DBCF7D960F898AAFA95 /* GCDWebServer */,
-				CAF0751214AFBE871D56A253826CE89D /* GKPhotoBrowser */,
-				98527D7196957AAB07B79E2E2AFDE23E /* IQKeyboardManager */,
-				8879D806A3C9D2BE8B14C1FD74191780 /* ISO8601 */,
-				BAACA1BF7AB3DD28402C4F9A7C2FD104 /* JSONModel */,
-				51BA97E8B5085EFFB47BC9C0B785CEA7 /* lottie-ios */,
-				1FFED36A657123030ABB700256D73F15 /* Masonry */,
-				2B276B0A79173A1D6E83C9B4FB9A4A57 /* MJExtension */,
-				F2710788070B90071961669CCFAC08B7 /* Pods-EulixSpace */,
-				E9216164016E5DAE5E8362FA322C4665 /* Pods-EulixSpaceTests */,
-				400FF55D0451E7A8F33A3D0D3E11C1B9 /* Reachability */,
-				612028EAFF1C2054A0EB821A9C9F2440 /* SAMKeychain */,
-				8B6CF5C20C32EE9F7F0862FF892524DE /* SDCycleScrollView */,
-				B0B214D775196BA7CA8E17E53048A493 /* SDWebImage */,
-				85A01882ED06DFEA2E0CE78BCDB204A7 /* SocketRocket */,
-				5DCCF5B5F792D4EC76585F50AC7D8D7B /* SQLiteRepairKit */,
-				91B23470DEB9A986332BEB5034234BC7 /* SSZipArchive */,
-				E97D43C46A45EE515A4DA3AF94398441 /* SVProgressHUD */,
-				0B2BA4641C180D2965DAF4B72EE9AE34 /* WCDB */,
-				B3CF92365D6AE0F35C3602CF6C0872AE /* WCDBOptimizedSQLCipher */,
-				84DD27E2166B82C1DE0C61D8A639B3D2 /* YCBase */,
-				287875A0B2464E74FEA1F211C5C586E5 /* YCEasyTool */,
-				48ACF38225AF5129416A1F090F6D3286 /* YYCache */,
-				E460D5B0416D36F66EE8EC89E5D2FA0A /* YYModel */,
+				A4FA15D44DF6BAC7550EDEED10862AA3 /* libAFNetworking.a */,
+				C261436D14052AE3C35F240BCD155CAC /* libCocoaLumberjack.a */,
+				03EBC375BDAF9B3A8C8050FCDD486C29 /* libFileMD5Hash.a */,
+				FAA5F2D71B90788C908800A94534AA92 /* libFLAnimatedImage.a */,
+				B68C1052A3B51DBCF7D960F898AAFA95 /* libGCDWebServer.a */,
+				CAF0751214AFBE871D56A253826CE89D /* libGKPhotoBrowser.a */,
+				98527D7196957AAB07B79E2E2AFDE23E /* libIQKeyboardManager.a */,
+				8879D806A3C9D2BE8B14C1FD74191780 /* libISO8601.a */,
+				BAACA1BF7AB3DD28402C4F9A7C2FD104 /* libJSONModel.a */,
+				51BA97E8B5085EFFB47BC9C0B785CEA7 /* liblottie-ios.a */,
+				1FFED36A657123030ABB700256D73F15 /* libMasonry.a */,
+				2B276B0A79173A1D6E83C9B4FB9A4A57 /* libMJExtension.a */,
+				F2710788070B90071961669CCFAC08B7 /* libPods-EulixSpace.a */,
+				E9216164016E5DAE5E8362FA322C4665 /* libPods-EulixSpaceTests.a */,
+				400FF55D0451E7A8F33A3D0D3E11C1B9 /* libReachability.a */,
+				612028EAFF1C2054A0EB821A9C9F2440 /* libSAMKeychain.a */,
+				8B6CF5C20C32EE9F7F0862FF892524DE /* libSDCycleScrollView.a */,
+				B0B214D775196BA7CA8E17E53048A493 /* libSDWebImage.a */,
+				85A01882ED06DFEA2E0CE78BCDB204A7 /* libSocketRocket.a */,
+				5DCCF5B5F792D4EC76585F50AC7D8D7B /* libSQLiteRepairKit.a */,
+				91B23470DEB9A986332BEB5034234BC7 /* libSSZipArchive.a */,
+				E97D43C46A45EE515A4DA3AF94398441 /* libSVProgressHUD.a */,
+				0B2BA4641C180D2965DAF4B72EE9AE34 /* libWCDB.a */,
+				B3CF92365D6AE0F35C3602CF6C0872AE /* libWCDBOptimizedSQLCipher.a */,
+				84DD27E2166B82C1DE0C61D8A639B3D2 /* libYCBase.a */,
+				287875A0B2464E74FEA1F211C5C586E5 /* libYCEasyTool.a */,
+				48ACF38225AF5129416A1F090F6D3286 /* libYYCache.a */,
+				E460D5B0416D36F66EE8EC89E5D2FA0A /* libYYModel.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -4801,7 +4779,6 @@
 				872E7E6A59F1D42BAB54E678A88FA8CB /* YYMemoryCache.m */,
 				D8C4D14DD976CC051195B0E67347F164 /* Support Files */,
 			);
-			name = YYCache;
 			path = YYCache;
 			sourceTree = "<group>";
 		};
@@ -4825,7 +4802,6 @@
 				F15CD16A97DB7F2B2156A5C46CA64C47 /* Support Files */,
 				D36825DEB1DF18E570E5628253DA0CB5 /* UIKit */,
 			);
-			name = AFNetworking;
 			path = AFNetworking;
 			sourceTree = "<group>";
 		};
@@ -4848,7 +4824,6 @@
 				789C2DC9F2272215F8096956436BC298 /* UIView+SDExtension.m */,
 				2CE81A5720322B3EE3DB7FC28487BCCD /* Support Files */,
 			);
-			name = SDCycleScrollView;
 			path = SDCycleScrollView;
 			sourceTree = "<group>";
 		};
@@ -4882,7 +4857,6 @@
 				E1FF069BF0ECF6724839EBEA693E0595 /* ViewController+MASAdditions.m */,
 				E04EF825120A42B3CE85F9FD8438954C /* Support Files */,
 			);
-			name = Masonry;
 			path = Masonry;
 			sourceTree = "<group>";
 		};
@@ -5649,7 +5623,7 @@
 			);
 			name = AFNetworking;
 			productName = AFNetworking;
-			productReference = A4FA15D44DF6BAC7550EDEED10862AA3 /* AFNetworking */;
+			productReference = A4FA15D44DF6BAC7550EDEED10862AA3 /* libAFNetworking.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		0B967D7F8561D42493EE289EC8D450D1 /* lottie-ios */ = {
@@ -5666,7 +5640,7 @@
 			);
 			name = "lottie-ios";
 			productName = "lottie-ios";
-			productReference = 51BA97E8B5085EFFB47BC9C0B785CEA7 /* lottie-ios */;
+			productReference = 51BA97E8B5085EFFB47BC9C0B785CEA7 /* liblottie-ios.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		1664EA1850F2A5D7B4C063C13A541D0F /* GKPhotoBrowser */ = {
@@ -5684,7 +5658,7 @@
 			);
 			name = GKPhotoBrowser;
 			productName = GKPhotoBrowser;
-			productReference = CAF0751214AFBE871D56A253826CE89D /* GKPhotoBrowser */;
+			productReference = CAF0751214AFBE871D56A253826CE89D /* libGKPhotoBrowser.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		1948D0B63D2CF6A48E18B0B292BC6091 /* SocketRocket */ = {
@@ -5701,7 +5675,7 @@
 			);
 			name = SocketRocket;
 			productName = SocketRocket;
-			productReference = 85A01882ED06DFEA2E0CE78BCDB204A7 /* SocketRocket */;
+			productReference = 85A01882ED06DFEA2E0CE78BCDB204A7 /* libSocketRocket.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		1C8D67D8B72D6BA42CCEDB648537A340 /* SVProgressHUD */ = {
@@ -5718,7 +5692,7 @@
 			);
 			name = SVProgressHUD;
 			productName = SVProgressHUD;
-			productReference = E97D43C46A45EE515A4DA3AF94398441 /* SVProgressHUD */;
+			productReference = E97D43C46A45EE515A4DA3AF94398441 /* libSVProgressHUD.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		3847153A6E5EEFB86565BA840768F429 /* SDWebImage */ = {
@@ -5735,7 +5709,7 @@
 			);
 			name = SDWebImage;
 			productName = SDWebImage;
-			productReference = B0B214D775196BA7CA8E17E53048A493 /* SDWebImage */;
+			productReference = B0B214D775196BA7CA8E17E53048A493 /* libSDWebImage.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		4612E6A85C01F0A85E41BCE99396EEEA /* Pods-EulixSpaceTests */ = {
@@ -5765,7 +5739,7 @@
 			);
 			name = "Pods-EulixSpaceTests";
 			productName = "Pods-EulixSpaceTests";
-			productReference = E9216164016E5DAE5E8362FA322C4665 /* Pods-EulixSpaceTests */;
+			productReference = E9216164016E5DAE5E8362FA322C4665 /* libPods-EulixSpaceTests.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		46B68FB361B0E581CECCA815555333A6 /* SQLiteRepairKit */ = {
@@ -5783,7 +5757,7 @@
 			);
 			name = SQLiteRepairKit;
 			productName = SQLiteRepairKit;
-			productReference = 5DCCF5B5F792D4EC76585F50AC7D8D7B /* SQLiteRepairKit */;
+			productReference = 5DCCF5B5F792D4EC76585F50AC7D8D7B /* libSQLiteRepairKit.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		49BBB123590B4A93869999AA45C7E68B /* FileMD5Hash */ = {
@@ -5800,7 +5774,7 @@
 			);
 			name = FileMD5Hash;
 			productName = FileMD5Hash;
-			productReference = 03EBC375BDAF9B3A8C8050FCDD486C29 /* FileMD5Hash */;
+			productReference = 03EBC375BDAF9B3A8C8050FCDD486C29 /* libFileMD5Hash.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		4A8E8992707D01510894596DB9BCCA00 /* FLAnimatedImage */ = {
@@ -5817,7 +5791,7 @@
 			);
 			name = FLAnimatedImage;
 			productName = FLAnimatedImage;
-			productReference = FAA5F2D71B90788C908800A94534AA92 /* FLAnimatedImage */;
+			productReference = FAA5F2D71B90788C908800A94534AA92 /* libFLAnimatedImage.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		4D3BA58D0583DF37575CACAB3DDADC85 /* MJExtension */ = {
@@ -5834,7 +5808,7 @@
 			);
 			name = MJExtension;
 			productName = MJExtension;
-			productReference = 2B276B0A79173A1D6E83C9B4FB9A4A57 /* MJExtension */;
+			productReference = 2B276B0A79173A1D6E83C9B4FB9A4A57 /* libMJExtension.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		5572D14DECB5A676C1B31B30A3BA7F10 /* SAMKeychain */ = {
@@ -5851,7 +5825,7 @@
 			);
 			name = SAMKeychain;
 			productName = SAMKeychain;
-			productReference = 612028EAFF1C2054A0EB821A9C9F2440 /* SAMKeychain */;
+			productReference = 612028EAFF1C2054A0EB821A9C9F2440 /* libSAMKeychain.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		55AF53E6C77A10ED4985E04D74A8878E /* Masonry */ = {
@@ -5868,7 +5842,7 @@
 			);
 			name = Masonry;
 			productName = Masonry;
-			productReference = 1FFED36A657123030ABB700256D73F15 /* Masonry */;
+			productReference = 1FFED36A657123030ABB700256D73F15 /* libMasonry.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		7AC2C6E1735146F1E0A04614976C5D18 /* WCDBOptimizedSQLCipher */ = {
@@ -5885,7 +5859,7 @@
 			);
 			name = WCDBOptimizedSQLCipher;
 			productName = WCDBOptimizedSQLCipher;
-			productReference = B3CF92365D6AE0F35C3602CF6C0872AE /* WCDBOptimizedSQLCipher */;
+			productReference = B3CF92365D6AE0F35C3602CF6C0872AE /* libWCDBOptimizedSQLCipher.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		7C79F5018610F9B1C59E7D0E6F0441A9 /* YCBase */ = {
@@ -5903,7 +5877,7 @@
 			);
 			name = YCBase;
 			productName = YCBase;
-			productReference = 84DD27E2166B82C1DE0C61D8A639B3D2 /* YCBase */;
+			productReference = 84DD27E2166B82C1DE0C61D8A639B3D2 /* libYCBase.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		8244686F5CA5654DB2B4C6BD52D2FB38 /* ISO8601 */ = {
@@ -5920,7 +5894,7 @@
 			);
 			name = ISO8601;
 			productName = ISO8601;
-			productReference = 8879D806A3C9D2BE8B14C1FD74191780 /* ISO8601 */;
+			productReference = 8879D806A3C9D2BE8B14C1FD74191780 /* libISO8601.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		84B44807A12996D487A4A591A481D6A0 /* YYModel */ = {
@@ -5937,7 +5911,7 @@
 			);
 			name = YYModel;
 			productName = YYModel;
-			productReference = E460D5B0416D36F66EE8EC89E5D2FA0A /* YYModel */;
+			productReference = E460D5B0416D36F66EE8EC89E5D2FA0A /* libYYModel.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		88280FCCAA3AE0C7640CB30F5A2E290F /* WCDB */ = {
@@ -5956,7 +5930,7 @@
 			);
 			name = WCDB;
 			productName = WCDB;
-			productReference = 0B2BA4641C180D2965DAF4B72EE9AE34 /* WCDB */;
+			productReference = 0B2BA4641C180D2965DAF4B72EE9AE34 /* libWCDB.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		9FB21AAC520D0EEC8775B6A1415E76A0 /* Pods-EulixSpace */ = {
@@ -6000,7 +5974,7 @@
 			);
 			name = "Pods-EulixSpace";
 			productName = "Pods-EulixSpace";
-			productReference = F2710788070B90071961669CCFAC08B7 /* Pods-EulixSpace */;
+			productReference = F2710788070B90071961669CCFAC08B7 /* libPods-EulixSpace.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		AD904F32069787EFB2DFFE05EB82F5BD /* GCDWebServer */ = {
@@ -6017,7 +5991,7 @@
 			);
 			name = GCDWebServer;
 			productName = GCDWebServer;
-			productReference = B68C1052A3B51DBCF7D960F898AAFA95 /* GCDWebServer */;
+			productReference = B68C1052A3B51DBCF7D960F898AAFA95 /* libGCDWebServer.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		B38E6AEB9731446FC60F30ECC3EFB074 /* YCEasyTool */ = {
@@ -6034,7 +6008,7 @@
 			);
 			name = YCEasyTool;
 			productName = YCEasyTool;
-			productReference = 287875A0B2464E74FEA1F211C5C586E5 /* YCEasyTool */;
+			productReference = 287875A0B2464E74FEA1F211C5C586E5 /* libYCEasyTool.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		CAA047C0F5E4106F3904E8497FA17F97 /* Reachability */ = {
@@ -6051,7 +6025,7 @@
 			);
 			name = Reachability;
 			productName = Reachability;
-			productReference = 400FF55D0451E7A8F33A3D0D3E11C1B9 /* Reachability */;
+			productReference = 400FF55D0451E7A8F33A3D0D3E11C1B9 /* libReachability.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		CBED833AAD6266F3AEFE9BE31C68E094 /* SDCycleScrollView */ = {
@@ -6069,7 +6043,7 @@
 			);
 			name = SDCycleScrollView;
 			productName = SDCycleScrollView;
-			productReference = 8B6CF5C20C32EE9F7F0862FF892524DE /* SDCycleScrollView */;
+			productReference = 8B6CF5C20C32EE9F7F0862FF892524DE /* libSDCycleScrollView.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		CFDAE6EB02F58B9A37CADCF439AE6082 /* YYCache */ = {
@@ -6086,7 +6060,7 @@
 			);
 			name = YYCache;
 			productName = YYCache;
-			productReference = 48ACF38225AF5129416A1F090F6D3286 /* YYCache */;
+			productReference = 48ACF38225AF5129416A1F090F6D3286 /* libYYCache.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		E0EAF4371C6E4B30A1779D513CB4355B /* JSONModel */ = {
@@ -6103,7 +6077,7 @@
 			);
 			name = JSONModel;
 			productName = JSONModel;
-			productReference = BAACA1BF7AB3DD28402C4F9A7C2FD104 /* JSONModel */;
+			productReference = BAACA1BF7AB3DD28402C4F9A7C2FD104 /* libJSONModel.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		E95654B155D25890BE8E26081FCA8265 /* CocoaLumberjack */ = {
@@ -6120,7 +6094,7 @@
 			);
 			name = CocoaLumberjack;
 			productName = CocoaLumberjack;
-			productReference = C261436D14052AE3C35F240BCD155CAC /* CocoaLumberjack */;
+			productReference = C261436D14052AE3C35F240BCD155CAC /* libCocoaLumberjack.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		F60E38364AFF5E1349FF07415B944396 /* SSZipArchive */ = {
@@ -6137,7 +6111,7 @@
 			);
 			name = SSZipArchive;
 			productName = SSZipArchive;
-			productReference = 91B23470DEB9A986332BEB5034234BC7 /* SSZipArchive */;
+			productReference = 91B23470DEB9A986332BEB5034234BC7 /* libSSZipArchive.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		FBA456CB50E371584C11231929A0971E /* IQKeyboardManager */ = {
@@ -6154,7 +6128,7 @@
 			);
 			name = IQKeyboardManager;
 			productName = IQKeyboardManager;
-			productReference = 98527D7196957AAB07B79E2E2AFDE23E /* IQKeyboardManager */;
+			productReference = 98527D7196957AAB07B79E2E2AFDE23E /* libIQKeyboardManager.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -6163,8 +6137,9 @@
 		BFDFE7DC352907FC980B868725387E98 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1240;
-				LastUpgradeCheck = 1240;
+				LastUpgradeCheck = 1600;
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 10.0";
@@ -7276,13 +7251,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3A7AB2AD63541577BF9673459EC250AF /* Pods-EulixSpaceTests.platform.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -7299,13 +7272,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D59AA0BD0401D306E15220722B2A5375 /* Pods-EulixSpaceTests.appstore.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -7324,9 +7295,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/YCBase/YCBase-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7348,9 +7318,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SocketRocket/SocketRocket-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7372,9 +7341,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/CocoaLumberjack/CocoaLumberjack-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7396,9 +7364,9 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_PREFIX_HEADER = "Target Support Files/YYModel/YYModel-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7420,9 +7388,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SDWebImage/SDWebImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7443,9 +7410,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SVProgressHUD/SVProgressHUD-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7467,9 +7433,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/YCBase/YCBase-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7490,9 +7455,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/YCBase/YCBase-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7514,9 +7478,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SDWebImage/SDWebImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7538,9 +7501,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/GCDWebServer/GCDWebServer-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7559,13 +7521,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 431F2B57347C2FCDE0F6AE109F82084B /* Pods-EulixSpaceTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -7584,9 +7544,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SocketRocket/SocketRocket-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7606,9 +7565,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SDCycleScrollView/SDCycleScrollView-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7630,9 +7588,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/IQKeyboardManager/IQKeyboardManager-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7653,9 +7610,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/YYCache/YYCache-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7677,9 +7633,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/YCEasyTool/YCEasyTool-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7701,10 +7656,11 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				ENABLE_MODULE_VERIFIER = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/SSZipArchive/SSZipArchive-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MODULEMAP_FILE = Headers/Public/SSZipArchive/SSZipArchive.modulemap;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7726,9 +7682,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/IQKeyboardManager/IQKeyboardManager-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7749,9 +7704,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SSZipArchive/SSZipArchive-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MODULEMAP_FILE = Headers/Public/SSZipArchive/SSZipArchive.modulemap;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -7773,9 +7727,9 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_PREFIX_HEADER = "Target Support Files/YYModel/YYModel-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7797,9 +7751,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/GCDWebServer/GCDWebServer-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7821,9 +7774,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/JSONModel/JSONModel-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7844,9 +7796,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SVProgressHUD/SVProgressHUD-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7868,10 +7819,11 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				ENABLE_MODULE_VERIFIER = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/SSZipArchive/SSZipArchive-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MODULEMAP_FILE = Headers/Public/SSZipArchive/SSZipArchive.modulemap;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7892,9 +7844,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/Reachability/Reachability-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7916,9 +7867,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/IQKeyboardManager/IQKeyboardManager-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7939,9 +7889,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/lottie-ios/lottie-ios-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7963,9 +7912,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/GKPhotoBrowser/GKPhotoBrowser-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -7988,9 +7936,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/ISO8601/ISO8601-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8012,9 +7959,9 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_PREFIX_HEADER = "Target Support Files/YYModel/YYModel-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8035,9 +7982,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/Masonry/Masonry-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8059,9 +8005,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SDCycleScrollView/SDCycleScrollView-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8083,9 +8028,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SAMKeychain/SAMKeychain-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8105,9 +8049,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/YCEasyTool/YCEasyTool-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8129,9 +8072,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SDCycleScrollView/SDCycleScrollView-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8181,9 +8123,11 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -8204,7 +8148,6 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -8218,9 +8161,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/AFNetworking/AFNetworking-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8241,8 +8183,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8260,9 +8201,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/YCBase/YCBase-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8284,9 +8224,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/AFNetworking/AFNetworking-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8307,10 +8246,11 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				ENABLE_MODULE_VERIFIER = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/SSZipArchive/SSZipArchive-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MODULEMAP_FILE = Headers/Public/SSZipArchive/SSZipArchive.modulemap;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8330,8 +8270,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8350,9 +8289,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/FileMD5Hash/FileMD5Hash-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8374,9 +8312,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/MJExtension/MJExtension-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8398,9 +8335,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/FLAnimatedImage/FLAnimatedImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8422,9 +8358,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/YCEasyTool/YCEasyTool-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8445,9 +8380,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SQLiteRepairKit/SQLiteRepairKit-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8467,9 +8401,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/GKPhotoBrowser/GKPhotoBrowser-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8492,9 +8425,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/ISO8601/ISO8601-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8516,9 +8448,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SVProgressHUD/SVProgressHUD-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8540,9 +8471,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/AFNetworking/AFNetworking-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8563,8 +8493,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8582,9 +8511,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/FileMD5Hash/FileMD5Hash-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8606,9 +8534,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/FLAnimatedImage/FLAnimatedImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8630,9 +8557,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/lottie-ios/lottie-ios-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8654,9 +8580,9 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_PREFIX_HEADER = "Target Support Files/YYModel/YYModel-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8678,9 +8604,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/YYCache/YYCache-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8701,9 +8626,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SDCycleScrollView/SDCycleScrollView-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8724,9 +8648,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SDCycleScrollView/SDCycleScrollView-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8748,9 +8671,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/GKPhotoBrowser/GKPhotoBrowser-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8800,9 +8722,11 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -8819,7 +8743,6 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
@@ -8834,9 +8757,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/AFNetworking/AFNetworking-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8857,9 +8779,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SAMKeychain/SAMKeychain-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8878,13 +8799,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 177A369962A3D78CE7EB877A85ADE025 /* Pods-EulixSpace.dev.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -8904,9 +8823,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/Reachability/Reachability-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8928,9 +8846,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SAMKeychain/SAMKeychain-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8951,9 +8868,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SocketRocket/SocketRocket-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8975,9 +8891,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/FLAnimatedImage/FLAnimatedImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -8999,9 +8914,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/WCDBOptimizedSQLCipher/WCDBOptimizedSQLCipher-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9019,13 +8933,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = AB90B1602595D1E60DB73043981A2FDF /* Pods-EulixSpaceTests.dev.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -9044,9 +8956,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SQLiteRepairKit/SQLiteRepairKit-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9068,9 +8979,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/Masonry/Masonry-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9092,9 +9002,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/CocoaLumberjack/CocoaLumberjack-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9117,9 +9026,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/CocoaLumberjack/CocoaLumberjack-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9142,9 +9050,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/WCDB/WCDB-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9166,9 +9073,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/JSONModel/JSONModel-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9190,9 +9096,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/WCDB/WCDB-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9213,8 +9118,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -9260,9 +9164,11 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -9279,7 +9185,6 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
@@ -9293,9 +9198,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/WCDB/WCDB-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9317,9 +9221,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/WCDBOptimizedSQLCipher/WCDBOptimizedSQLCipher-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9341,9 +9244,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/WCDBOptimizedSQLCipher/WCDBOptimizedSQLCipher-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9365,9 +9267,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/FLAnimatedImage/FLAnimatedImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9416,9 +9317,11 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -9435,7 +9338,6 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
@@ -9450,9 +9352,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/FileMD5Hash/FileMD5Hash-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9473,9 +9374,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/CocoaLumberjack/CocoaLumberjack-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9498,9 +9398,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/GCDWebServer/GCDWebServer-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9521,9 +9420,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/Masonry/Masonry-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9573,9 +9471,11 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -9592,7 +9492,6 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
@@ -9607,9 +9506,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/MJExtension/MJExtension-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9630,9 +9528,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/GCDWebServer/GCDWebServer-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9653,9 +9550,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/WCDBOptimizedSQLCipher/WCDBOptimizedSQLCipher-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9677,9 +9573,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/lottie-ios/lottie-ios-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9701,9 +9596,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/ISO8601/ISO8601-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9725,9 +9619,9 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_PREFIX_HEADER = "Target Support Files/YYModel/YYModel-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9748,9 +9642,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/JSONModel/JSONModel-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9772,9 +9665,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SDWebImage/SDWebImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9796,9 +9688,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/WCDB/WCDB-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9819,9 +9710,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/ISO8601/ISO8601-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9844,9 +9734,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/ISO8601/ISO8601-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9867,9 +9756,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/Masonry/Masonry-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9890,9 +9778,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/YYCache/YYCache-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9914,9 +9801,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/WCDB/WCDB-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9938,9 +9824,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SAMKeychain/SAMKeychain-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9962,9 +9847,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/GKPhotoBrowser/GKPhotoBrowser-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -9982,13 +9866,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D44C2ED14B05B58206AE9FF6C17697A1 /* Pods-EulixSpace.platform.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -10007,9 +9889,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/IQKeyboardManager/IQKeyboardManager-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10032,9 +9913,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/FileMD5Hash/FileMD5Hash-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10056,9 +9936,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SQLiteRepairKit/SQLiteRepairKit-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10080,9 +9959,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/Masonry/Masonry-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10103,9 +9981,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/lottie-ios/lottie-ios-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10127,9 +10004,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/YYCache/YYCache-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10151,9 +10027,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/YYCache/YYCache-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10175,9 +10050,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/AFNetworking/AFNetworking-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10199,9 +10073,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/GKPhotoBrowser/GKPhotoBrowser-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10223,9 +10096,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/Reachability/Reachability-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10243,13 +10115,11 @@
 		BFA3956B7D54C216AEEFC52B5BE05A00 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -10269,10 +10139,11 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				ENABLE_MODULE_VERIFIER = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/SSZipArchive/SSZipArchive-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MODULEMAP_FILE = Headers/Public/SSZipArchive/SSZipArchive.modulemap;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10294,9 +10165,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SVProgressHUD/SVProgressHUD-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10315,8 +10185,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -10334,9 +10203,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/JSONModel/JSONModel-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10354,13 +10222,11 @@
 		C6A6288242C144204092F9815A91A636 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -10377,13 +10243,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3D9CCBA60ECA18E30B4C1381CA805CF9 /* Pods-EulixSpace.appstore.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -10402,9 +10266,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/FLAnimatedImage/FLAnimatedImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10426,9 +10289,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SVProgressHUD/SVProgressHUD-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10450,9 +10312,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/YCEasyTool/YCEasyTool-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10475,9 +10336,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/FileMD5Hash/FileMD5Hash-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10497,9 +10357,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SDWebImage/SDWebImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10521,9 +10380,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/CocoaLumberjack/CocoaLumberjack-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10546,9 +10404,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/YCBase/YCBase-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10570,9 +10427,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SQLiteRepairKit/SQLiteRepairKit-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10594,9 +10450,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SocketRocket/SocketRocket-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10618,9 +10473,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/IQKeyboardManager/IQKeyboardManager-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10642,9 +10496,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/Reachability/Reachability-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10666,9 +10519,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SQLiteRepairKit/SQLiteRepairKit-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10690,9 +10542,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/YCEasyTool/YCEasyTool-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10714,9 +10565,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SDWebImage/SDWebImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10738,9 +10588,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/lottie-ios/lottie-ios-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10761,9 +10610,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/MJExtension/MJExtension-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10785,9 +10633,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/MJExtension/MJExtension-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10805,13 +10652,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 476FDECC1B8E3E0E54CE4AD50A06CA15 /* Pods-EulixSpace.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
@@ -10830,9 +10675,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/JSONModel/JSONModel-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10853,9 +10697,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SocketRocket/SocketRocket-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10877,9 +10720,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/WCDBOptimizedSQLCipher/WCDBOptimizedSQLCipher-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10901,9 +10743,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/GCDWebServer/GCDWebServer-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10924,9 +10765,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/Reachability/Reachability-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10947,9 +10787,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/MJExtension/MJExtension-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";
@@ -10971,9 +10810,8 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREFIX_HEADER = "Target Support Files/SAMKeychain/SAMKeychain-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = "";


### PR DESCRIPTION
## Summary
  This PR improves iOS client behavior in simplified deployment mode (LAN-first,

  ## What Changed
  - Added iOS submodule `.gitignore` for:
    - `*.xcodeproj/xcuserdata/`
    - `*.xcworkspace/xcuserdata/`
    - `Pods/*.xcodeproj/xcuserdata/`
    - `build/`
  - Improved active box/host routing:
    - Prefer active LAN host and prevent fallback to stale box entries.
    - Reduced chance of requests drifting to invalid or old hosts.
  - Enhanced gateway/network logging paths for clearer error analysis.
  - Adjusted bind and transfer related flow handling for simplified mode.
  - Added/updated iOS tests for:
    - host routing safety
    - LAN cert response compatibility
  - Synced Xcode/Pods project metadata (`project.pbxproj`, `Podfile` updates).

  ## Why
  During regression and device-side validation, we observed stale host fallback
  and weak visibility in request routing failures. This change improves stability
  and debugging efficiency in LAN-first setups.

  ## Validation
  - iOS unit tests executed successfully in local simulator workflow.
  - Manual core-flow checks completed in simplified deployment:
    - bind device
    - create space
    - upload/download
    - device info

  ## Impact
  - Scope is iOS client only.
  - No server API contract changes.

Generated-by: Codex